### PR TITLE
Improve Zotero type definitions

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -93,8 +93,32 @@ export interface Tag {
 }
 
 export interface Relations {
-	'dc:replaces'?: string[] | string;
-	'dc:relation'?: string;
+        'dc:replaces'?: string[] | string;
+        'dc:relation'?: string;
+}
+
+/**
+ * Raw item object returned directly from the Zotero API.
+ */
+export interface ZoteroItemResponse {
+        key: string;
+        version: number;
+        message?: string;
+        rem?: Record<string, unknown> | null;
+        data?: Partial<ZoteroItemData>;
+        relations?: Relations;
+}
+
+/**
+ * Raw collection object returned directly from the Zotero API.
+ */
+export interface ZoteroCollectionResponse {
+        key: string;
+        version: number;
+        name?: string;
+        parentCollection?: string | false;
+        rem?: Record<string, unknown> | null;
+        relations?: Record<string, string>;
 }
 
 export enum ItemType {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,6 +1,30 @@
 import type { Rem } from '@remnote/plugin-sdk';
 
 /**
+ * Raw item object returned directly from the Zotero API.
+ */
+export interface ZoteroItemResponse {
+	key: string;
+	version: number;
+	message?: string;
+	rem?: Record<string, unknown> | null;
+	data?: Partial<ZoteroItemData>;
+	relations?: Relations;
+}
+
+/**
+ * Raw collection object returned directly from the Zotero API.
+ */
+export interface ZoteroCollectionResponse {
+	key: string;
+	version: number;
+	name?: string;
+	parentCollection?: string | false;
+	rem?: Record<string, unknown> | null;
+	relations?: Record<string, string>;
+}
+
+/**
  * Detailed data for a Zotero item. This attempts to mirror the fields
  * returned by the Zotero Web API. All fields are optional because not every
  * item type makes use of every field.
@@ -93,32 +117,8 @@ export interface Tag {
 }
 
 export interface Relations {
-        'dc:replaces'?: string[] | string;
-        'dc:relation'?: string;
-}
-
-/**
- * Raw item object returned directly from the Zotero API.
- */
-export interface ZoteroItemResponse {
-        key: string;
-        version: number;
-        message?: string;
-        rem?: Record<string, unknown> | null;
-        data?: Partial<ZoteroItemData>;
-        relations?: Relations;
-}
-
-/**
- * Raw collection object returned directly from the Zotero API.
- */
-export interface ZoteroCollectionResponse {
-        key: string;
-        version: number;
-        name?: string;
-        parentCollection?: string | false;
-        rem?: Record<string, unknown> | null;
-        relations?: Record<string, string>;
+	'dc:replaces'?: string[] | string;
+	'dc:relation'?: string;
 }
 
 export enum ItemType {

--- a/src/utils/zoteroConverters.ts
+++ b/src/utils/zoteroConverters.ts
@@ -21,7 +21,7 @@ export function fromZoteroItem(raw: ZoteroItemResponse): Item {
 
 export function fromZoteroCollection(raw: ZoteroCollectionResponse): Collection {
 	return {
-		rem: raw.rem ?? null,
+		rem: null,
 		key: raw.key,
 		version: raw.version,
 		name: raw.name ?? '',

--- a/src/utils/zoteroConverters.ts
+++ b/src/utils/zoteroConverters.ts
@@ -25,7 +25,7 @@ export function fromZoteroCollection(raw: ZoteroCollectionResponse): Collection 
 		key: raw.key,
 		version: raw.version,
 		name: raw.name ?? '',
-		parentCollection: typeof raw.parentCollection === 'string' ? raw.parentCollection : '',
+		parentCollection: raw.parentCollection || '',
 		relations: raw.relations ?? {},
 	};
 }

--- a/src/utils/zoteroConverters.ts
+++ b/src/utils/zoteroConverters.ts
@@ -1,31 +1,31 @@
 import type {
-       Collection,
-       Item,
-       ZoteroCollectionResponse,
-       ZoteroItemResponse,
+	Collection,
+	Item,
+	ZoteroCollectionResponse,
+	ZoteroItemResponse,
 } from '../types/types';
 
 export function fromZoteroItem(raw: ZoteroItemResponse): Item {
-        return {
-                key: raw.key,
-                version: raw.version,
-                message: raw.message,
-                rem: null,
-                data: {
-                        key: raw.key,
-                        version: raw.version,
-                        ...raw.data,
-                },
-        } as Item;
+	return {
+		key: raw.key,
+		version: raw.version,
+		message: raw.message,
+		rem: null,
+		data: {
+			key: raw.key,
+			version: raw.version,
+			...raw.data,
+		},
+	} as Item;
 }
 
 export function fromZoteroCollection(raw: ZoteroCollectionResponse): Collection {
-        return {
-                rem: null,
-                key: raw.key,
-                version: raw.version,
-                name: raw.name ?? '',
-                parentCollection: typeof raw.parentCollection === 'string' ? raw.parentCollection : '',
-                relations: raw.relations ?? {},
-        } as Collection;
+	return {
+		rem: null,
+		key: raw.key,
+		version: raw.version,
+		name: raw.name ?? '',
+		parentCollection: typeof raw.parentCollection === 'string' ? raw.parentCollection : '',
+		relations: raw.relations ?? {},
+	} as Collection;
 }

--- a/src/utils/zoteroConverters.ts
+++ b/src/utils/zoteroConverters.ts
@@ -1,26 +1,31 @@
-import type { Collection, Item } from '../types/types';
+import type {
+       Collection,
+       Item,
+       ZoteroCollectionResponse,
+       ZoteroItemResponse,
+} from '../types/types';
 
-export function fromZoteroItem(raw: any) {
-	return {
-		key: raw.key,
-		version: raw.version,
-		message: raw.message,
-		rem: null,
-		data: {
-			key: raw.key,
-			version: raw.version,
-			...raw.data,
-		},
-	} as Item;
+export function fromZoteroItem(raw: ZoteroItemResponse): Item {
+        return {
+                key: raw.key,
+                version: raw.version,
+                message: raw.message,
+                rem: null,
+                data: {
+                        key: raw.key,
+                        version: raw.version,
+                        ...raw.data,
+                },
+        } as Item;
 }
 
-export function fromZoteroCollection(raw: any) {
-	return {
-		rem: null,
-		key: raw.key,
-		version: raw.version,
-		name: raw.data?.name ?? '',
-		parentCollection: raw.data?.parentCollection ?? '',
-		relations: raw.relations ?? {},
-	} as Collection;
+export function fromZoteroCollection(raw: ZoteroCollectionResponse): Collection {
+        return {
+                rem: null,
+                key: raw.key,
+                version: raw.version,
+                name: raw.name ?? '',
+                parentCollection: typeof raw.parentCollection === 'string' ? raw.parentCollection : '',
+                relations: raw.relations ?? {},
+        } as Collection;
 }

--- a/src/utils/zoteroConverters.ts
+++ b/src/utils/zoteroConverters.ts
@@ -21,7 +21,7 @@ export function fromZoteroItem(raw: ZoteroItemResponse): Item {
 
 export function fromZoteroCollection(raw: ZoteroCollectionResponse): Collection {
 	return {
-		rem: null,
+		rem: raw.rem ?? null,
 		key: raw.key,
 		version: raw.version,
 		name: raw.name ?? '',

--- a/src/utils/zoteroConverters.ts
+++ b/src/utils/zoteroConverters.ts
@@ -27,5 +27,5 @@ export function fromZoteroCollection(raw: ZoteroCollectionResponse): Collection 
 		name: raw.name ?? '',
 		parentCollection: typeof raw.parentCollection === 'string' ? raw.parentCollection : '',
 		relations: raw.relations ?? {},
-	} as Collection;
+	};
 }


### PR DESCRIPTION
## Summary
- add interfaces `ZoteroItemResponse` and `ZoteroCollectionResponse`
- use new interfaces in `zoteroConverters`

## Testing
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_685c54018f5c83249e86373b1ce093ab