### PR TITLE
Handle parent items before marking as unfiled

### DIFF
--- a/src/sync/treeBuilder.ts
+++ b/src/sync/treeBuilder.ts
@@ -266,35 +266,35 @@ export class TreeBuilder {
 		for (const item of items) {
 			const remNode = this.nodeCache.get(item.key);
 			if (remNode) {
-                                const parentNodes: RemNode[] = [];
-                                // Include parentItem if available.
-                                if (item.data.parentItem) {
-                                        const parentItemNode = this.nodeCache.get(item.data.parentItem);
-                                        if (parentItemNode) parentNodes.push(parentItemNode);
-                                }
-                                // Include collections.
-                                if (item.data.collections && item.data.collections.length > 0) {
-                                        for (const collectionId of item.data.collections) {
-                                                const collectionNode = this.nodeCache.get(collectionId);
-                                                if (collectionNode) {
-                                                        parentNodes.push(collectionNode);
-                                                } else {
-                                                        console.warn(
-                                                                `Collection ${collectionId} not found for item ${item.key}`
-                                                        );
-                                                }
-                                        }
-                                }
+				const parentNodes: RemNode[] = [];
+				// Include parentItem if available.
+				if (item.data.parentItem) {
+					const parentItemNode = this.nodeCache.get(item.data.parentItem);
+					if (parentItemNode) parentNodes.push(parentItemNode);
+				}
+				// Include collections.
+				if (item.data.collections && item.data.collections.length > 0) {
+					for (const collectionId of item.data.collections) {
+						const collectionNode = this.nodeCache.get(collectionId);
+						if (collectionNode) {
+							parentNodes.push(collectionNode);
+						} else {
+							console.warn(
+								`Collection ${collectionId} not found for item ${item.key}`
+							);
+						}
+					}
+				}
 
-                                if (parentNodes.length === 0) {
-                                        listOfUnfiledItems.push(item);
-                                        if (unfiledZoteroItemsRem) {
-                                                await remNode.rem.setParent(unfiledZoteroItemsRem);
-                                        }
-                                        continue;
-                                }
+				if (parentNodes.length === 0) {
+					listOfUnfiledItems.push(item);
+					if (unfiledZoteroItemsRem) {
+						await remNode.rem.setParent(unfiledZoteroItemsRem);
+					}
+					continue;
+				}
 
-                                if (parentNodes.length > 0) {
+				if (parentNodes.length > 0) {
 					const primaryParent = parentNodes[0];
 					await remNode.rem.setParent(primaryParent.rem);
 					if (multipleCollectionsBehavior === 'portal') {

--- a/src/sync/treeBuilder.ts
+++ b/src/sync/treeBuilder.ts
@@ -266,32 +266,35 @@ export class TreeBuilder {
 		for (const item of items) {
 			const remNode = this.nodeCache.get(item.key);
 			if (remNode) {
-				const parentNodes: RemNode[] = [];
-				// Include parentItem if available.
-				if (item.data.parentItem) {
-					const parentItemNode = this.nodeCache.get(item.data.parentItem);
-					if (parentItemNode) parentNodes.push(parentItemNode);
-				}
-				// Include collections.
-				if (item.data.collections && item.data.collections.length > 0) {
-					for (const collectionId of item.data.collections) {
-						const collectionNode = this.nodeCache.get(collectionId);
-						if (collectionNode) {
-							parentNodes.push(collectionNode);
-						} else {
-							console.warn(
-								`Collection ${collectionId} not found for item ${item.key}`
-							);
-						}
-					}
-				} else {
-					listOfUnfiledItems.push(item);
-					if (unfiledZoteroItemsRem) {
-						await remNode.rem.setParent(unfiledZoteroItemsRem);
-					}
-					continue;
-				}
-				if (parentNodes.length > 0) {
+                                const parentNodes: RemNode[] = [];
+                                // Include parentItem if available.
+                                if (item.data.parentItem) {
+                                        const parentItemNode = this.nodeCache.get(item.data.parentItem);
+                                        if (parentItemNode) parentNodes.push(parentItemNode);
+                                }
+                                // Include collections.
+                                if (item.data.collections && item.data.collections.length > 0) {
+                                        for (const collectionId of item.data.collections) {
+                                                const collectionNode = this.nodeCache.get(collectionId);
+                                                if (collectionNode) {
+                                                        parentNodes.push(collectionNode);
+                                                } else {
+                                                        console.warn(
+                                                                `Collection ${collectionId} not found for item ${item.key}`
+                                                        );
+                                                }
+                                        }
+                                }
+
+                                if (parentNodes.length === 0) {
+                                        listOfUnfiledItems.push(item);
+                                        if (unfiledZoteroItemsRem) {
+                                                await remNode.rem.setParent(unfiledZoteroItemsRem);
+                                        }
+                                        continue;
+                                }
+
+                                if (parentNodes.length > 0) {
 					const primaryParent = parentNodes[0];
 					await remNode.rem.setParent(primaryParent.rem);
 					if (multipleCollectionsBehavior === 'portal') {


### PR DESCRIPTION
## Summary
- fix moveItems so attachments with `parentItem` aren't marked unfiled when they lack collections

## Testing
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_685dc0492bdc83248031beec008e2549