### PR TITLE
Ensure deletion completion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -266,15 +266,14 @@ async function registerPowerups(plugin: RNPlugin) {
 }
 
 async function _deleteTaggedRems(plugin: RNPlugin, powerupCodes: string[]): Promise<void> {
-	for (const code of powerupCodes) {
-		const powerup = await plugin.powerup.getPowerupByCode(code);
-		const taggedRems = await powerup?.taggedRem();
-		if (taggedRems) {
-			for (const rem of taggedRems) {
-				await rem?.remove();
-			}
-		}
-	}
+        for (const code of powerupCodes) {
+                const powerup = await plugin.powerup.getPowerupByCode(code);
+                const taggedRems = await powerup?.taggedRem();
+                if (taggedRems) {
+                        const removalPromises = taggedRems.map((rem) => rem?.remove());
+                        await Promise.all(removalPromises);
+                }
+        }
 }
 
 async function registerDebugCommands(plugin: RNPlugin) {
@@ -377,18 +376,17 @@ async function registerDebugCommands(plugin: RNPlugin) {
 				const unfiledItemsPowerup = await plugin.powerup.getPowerupByCode(
 					powerupCodes.ZOTERO_UNFILED_ITEMS
 				);
-				const taggedRems = await Promise.all([
-					zoteroItemPowerup?.taggedRem(),
-					zoteroCollectionPowerup?.taggedRem(),
-					zoteroLibraryPowerup?.taggedRem(),
-					citationistaPowerup?.taggedRem(),
-					unfiledItemsPowerup?.taggedRem(),
-				]).then((results) => results.flat());
-				if (taggedRems) {
-					taggedRems.forEach(async (rem) => {
-						await rem?.remove();
-					});
-				}
+                                const taggedRems = await Promise.all([
+                                        zoteroItemPowerup?.taggedRem(),
+                                        zoteroCollectionPowerup?.taggedRem(),
+                                        zoteroLibraryPowerup?.taggedRem(),
+                                        citationistaPowerup?.taggedRem(),
+                                        unfiledItemsPowerup?.taggedRem(),
+                                ]).then((results) => results.flat());
+                                if (taggedRems) {
+                                        const removalPromises = taggedRems.map((rem) => rem?.remove());
+                                        await Promise.all(removalPromises);
+                                }
 			}
 		},
 	});

--- a/src/sync/treeBuilder.ts
+++ b/src/sync/treeBuilder.ts
@@ -174,15 +174,17 @@ export class TreeBuilder {
 		}
 	}
 
-	private async deleteCollections(collections: Collection[]): Promise<void> {
-		for (const collection of collections) {
-			const remNode = this.nodeCache.get(collection.key);
-			if (remNode) {
-				await remNode.rem.remove();
-				this.nodeCache.delete(collection.key);
-			}
-		}
-	}
+        private async deleteCollections(collections: Collection[]): Promise<void> {
+                const deletionPromises: Promise<void>[] = [];
+                for (const collection of collections) {
+                        const remNode = this.nodeCache.get(collection.key);
+                        if (remNode) {
+                                deletionPromises.push(remNode.rem.remove());
+                                this.nodeCache.delete(collection.key);
+                        }
+                }
+                await Promise.all(deletionPromises);
+        }
 
 	private async moveCollections(collections: Collection[]): Promise<void> {
 		for (const collection of collections) {
@@ -246,15 +248,17 @@ export class TreeBuilder {
 		}
 	}
 
-	private async deleteItems(items: Item[]): Promise<void> {
-		for (const item of items) {
-			const remNode = this.nodeCache.get(item.key);
-			if (remNode) {
-				await remNode.rem.remove();
-				this.nodeCache.delete(item.key);
-			}
-		}
-	}
+        private async deleteItems(items: Item[]): Promise<void> {
+                const deletionPromises: Promise<void>[] = [];
+                for (const item of items) {
+                        const remNode = this.nodeCache.get(item.key);
+                        if (remNode) {
+                                deletionPromises.push(remNode.rem.remove());
+                                this.nodeCache.delete(item.key);
+                        }
+                }
+                await Promise.all(deletionPromises);
+        }
 
 	private async moveItems(items: Item[]): Promise<void> {
 		const unfiledZoteroItemsRem = await getUnfiledItemsRem(this.plugin);


### PR DESCRIPTION
## Summary
- await deletion of Rems concurrently in `treeBuilder`
- await deletion of tagged Rems in debug utilities

## Testing
- `npm run check-types` *(fails: exportCitations.ts cannot be compiled under --isolatedModules)*

------
https://chatgpt.com/codex/tasks/task_e_6865c36ae95c83249e0db2ebdd8d8277