### PR TITLE
Add group library support

### DIFF
--- a/src/api/zotero.ts
+++ b/src/api/zotero.ts
@@ -2,7 +2,12 @@
 import type { RNPlugin } from '@remnote/plugin-sdk';
 // @ts-ignore
 import createZoteroClient from 'zotero-api-client';
-import type { Collection, Item, ZoteroCollectionResponse, ZoteroItemResponse } from '../types/types';
+import type {
+	Collection,
+	Item,
+	ZoteroCollectionResponse,
+	ZoteroItemResponse,
+} from '../types/types';
 import { fromZoteroCollection, fromZoteroItem } from '../utils/zoteroConverters';
 
 /**
@@ -27,42 +32,64 @@ import { fromZoteroCollection, fromZoteroItem } from '../utils/zoteroConverters'
  *	const { items, collections } = await api.fetchLibraryData();
  * ```
  */
+export interface ZoteroLibraryInfo {
+	id: string;
+	name: string;
+	type: 'user' | 'group';
+}
+
 export class ZoteroAPI {
-        private plugin: RNPlugin;
-        // biome-ignore lint/suspicious/noExplicitAny: how it was in the original code idk :?
-        private zoteroConnection: any | null = null;
+	private plugin: RNPlugin;
+	// biome-ignore lint/suspicious/noExplicitAny: how it was in the original code idk :?
+	private zoteroConnection: any | null = null;
 
 	constructor(plugin: RNPlugin) {
 		this.plugin = plugin;
 	}
 
 	// biome-ignore lint/suspicious/noExplicitAny: how it was in the original code idk :?
-        private async getOrCreateConnection(): Promise<any> {
-                if (this.zoteroConnection) return this.zoteroConnection;
+	private async getOrCreateConnection(
+		libraryType?: 'user' | 'group',
+		libraryId?: string
+	): Promise<any> {
+		if (this.zoteroConnection) return this.zoteroConnection;
 
 		const apiKey = await this.plugin.settings.getSetting('zotero-api-key');
-		const userId = await this.plugin.settings.getSetting('zotero-user-id');
-
 		if (!apiKey) {
 			throw new Error('Zotero API key not set');
 		}
-		if (!userId) {
-			throw new Error('Zotero User ID not set');
+
+		if (!libraryType || !libraryId) {
+			const stored = await this.plugin.settings.getSetting('zotero-library-id');
+			if (stored && typeof stored === 'string') {
+				const [type, id] = stored.split(':');
+				libraryType = (type as 'user' | 'group') || libraryType;
+				libraryId = id || libraryId;
+			}
 		}
 
-                this.zoteroConnection = await createZoteroClient(apiKey).library('user', userId);
-                return this.zoteroConnection;
+		if (!libraryType || !libraryId) {
+			libraryType = 'user';
+			libraryId = await this.plugin.settings.getSetting('zotero-user-id');
+		}
+
+		if (!libraryId) {
+			throw new Error('Zotero Library ID not set');
+		}
+
+		this.zoteroConnection = await createZoteroClient(apiKey).library(libraryType, libraryId);
+		return this.zoteroConnection;
 	}
 
-        private async fetchItems(): Promise<Item[]> {
+	private async fetchItems(): Promise<Item[]> {
 		try {
-                        const apiConnection = await this.getOrCreateConnection();
+			const apiConnection = await this.getOrCreateConnection();
 			const items: Item[] = [];
 			let start = 0;
 			const limit = 100; // Maximize limit to reduce number of requests
 
 			while (true) {
-                                const response = await apiConnection.items().get({ start, limit });
+				const response = await apiConnection.items().get({ start, limit });
 				const rawItems = response.raw as ZoteroItemResponse[];
 				for (const raw of rawItems) {
 					items.push(fromZoteroItem(raw));
@@ -84,10 +111,10 @@ export class ZoteroAPI {
 		}
 	}
 
-        private async fetchCollections(): Promise<Collection[]> {
+	private async fetchCollections(): Promise<Collection[]> {
 		try {
-                        const apiConnection = await this.getOrCreateConnection();
-                        const response = await apiConnection.collections().get();
+			const apiConnection = await this.getOrCreateConnection();
+			const response = await apiConnection.collections().get();
 			const rawCollections = response.getData() as ZoteroCollectionResponse[];
 			return rawCollections.map(fromZoteroCollection);
 		} catch (error) {
@@ -97,13 +124,43 @@ export class ZoteroAPI {
 		}
 	}
 
-        async fetchLibraryData(): Promise<{ items: Item[]; collections: Collection[] }> {
-                const [items, collections] = await Promise.all([this.fetchItems(), this.fetchCollections()]);
+	async fetchLibraryData(): Promise<{ items: Item[]; collections: Collection[] }> {
+		const [items, collections] = await Promise.all([
+			this.fetchItems(),
+			this.fetchCollections(),
+		]);
 		console.log(
 			`Fetched ${items.length} items and ${collections.length} collections from Zotero.`,
 			items,
 			collections
 		);
 		return { items, collections };
+	}
+}
+
+export async function fetchLibraries(plugin: RNPlugin): Promise<ZoteroLibraryInfo[]> {
+	const apiKey = await plugin.settings.getSetting('zotero-api-key');
+	const userId = await plugin.settings.getSetting('zotero-user-id');
+
+	if (!apiKey || !userId) {
+		return [];
+	}
+
+	const headers = { 'Zotero-API-Key': String(apiKey) };
+	try {
+		const res = await fetch(`https://api.zotero.org/users/${userId}/groups`, { headers });
+		if (!res.ok) {
+			throw new Error(`HTTP ${res.status}`);
+		}
+		const data = (await res.json()) as any[];
+		const groups = data.map((g) => ({
+			id: String(g.id ?? g.data?.id),
+			name: g.data?.name ?? g.name ?? '',
+			type: 'group' as const,
+		}));
+		return [{ id: String(userId), name: 'My Library', type: 'user' as const }, ...groups];
+	} catch (err) {
+		console.error('Failed to fetch group libraries', err);
+		return [{ id: String(userId), name: 'My Library', type: 'user' }];
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { markForceStopRequested } from './services/pluginIO';
 import { registerItemPowerups } from './services/zoteroSchemaToRemNote';
 import { ZoteroSyncManager } from './sync/zoteroSyncManager';
 import { LogType, logMessage } from './utils/logging';
+import { fetchLibraries } from './api/zotero';
 
 let autoSyncInterval: NodeJS.Timeout | undefined;
 
@@ -29,6 +30,19 @@ async function registerSettings(plugin: RNPlugin) {
 		title: 'Zotero API Key',
 		description:
 			'Find this at https://www.zotero.org/settings/keys. Make sure to enable all read/write for all features to work. But feel free to disable any you do not need.',
+	});
+
+	const libraries = await fetchLibraries(plugin);
+	await plugin.settings.registerDropdownSetting({
+		id: 'zotero-library-id',
+		title: 'Zotero Library',
+		description: 'Select which Zotero library to sync with.',
+		options: libraries.map((lib) => ({
+			key: `${lib.type}:${lib.id}`,
+			label: lib.type === 'group' ? `Group: ${lib.name}` : 'My Library',
+			value: `${lib.type}:${lib.id}`,
+		})),
+		defaultValue: libraries.length > 0 ? `${libraries[0].type}:${libraries[0].id}` : undefined,
 	});
 	await plugin.settings.registerBooleanSetting({
 		id: 'simple-mode',

--- a/src/services/exportCitations.ts
+++ b/src/services/exportCitations.ts
@@ -1,1 +1,2 @@
 // export citations command (later on, (TODO:) we may want a export citations and add to zotero library command as an ext to this command)
+export {};


### PR DESCRIPTION
## Summary
- add ability to choose Zotero library
- fetch user groups to populate library dropdown
- connect to selected library
- silence TypeScript error in exportCitations

## Testing
- `npm run check-types`

------
https://chatgpt.com/codex/tasks/task_e_68682e2e8af48324adbc662f2da733ed