### PR TITLE
Switch sync status to session storage

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -54,10 +54,15 @@
 			"powerupCode": "coolPool",
 			"level": "ReadCreateModifyDelete"
 		},
-		{
-			"type": "Powerup",
-			"powerupCode": "zotero-unfiled-items",
-			"level": "ReadCreateModifyDelete"
-		}
-	]
+                {
+                        "type": "Powerup",
+                        "powerupCode": "zotero-unfiled-items",
+                        "level": "ReadCreateModifyDelete"
+                },
+                {
+                        "type": "Powerup",
+                        "powerupCode": "zotero-connector-home",
+                        "level": "ReadCreateModifyDelete"
+                }
+        ]
 }

--- a/src/api/zotero.ts
+++ b/src/api/zotero.ts
@@ -159,7 +159,6 @@ export async function fetchLibraries(plugin: RNPlugin): Promise<ZoteroLibraryInf
 
 	const headers = { 'Zotero-API-Key': String(apiKey) };
 
-
 	// Use proxy in development mode to avoid CORS issues
 	const baseUrl = process.env.NODE_ENV === 'development' ? '/zotero' : 'https://api.zotero.org';
 
@@ -171,7 +170,6 @@ export async function fetchLibraries(plugin: RNPlugin): Promise<ZoteroLibraryInf
 			const userData = (await resUser.json()) as any;
 			userName = userData?.data?.profileName || userData?.data?.username || userName;
 		}
-
 
 		const res = await fetch(`${baseUrl}/users/${userId}/groups`, { headers });
 

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -41,12 +41,13 @@ export const WIKIPEDIA_API_HEADERS = new Headers({
 // in case they need to contact me, they can find us by the name of the plugin or my username
 
 export const powerupCodes = {
-	ZOTERO_SYNCED_LIBRARY: 'zotero-synced-library',
-	ZITEM: 'zitem',
-	COLLECTION: 'collection',
-	ZOTERO_TAG: 'zotero-tag',
-	ZOTERO_NOTE: 'zotero-note',
-	ZITEM_ATTACHMENT: 'zitem-attachment',
-	CITATION_POOL: 'coolPool',
-	ZOTERO_UNFILED_ITEMS: 'zotero-unfiled-items',
+        ZOTERO_SYNCED_LIBRARY: 'zotero-synced-library',
+        ZITEM: 'zitem',
+        COLLECTION: 'collection',
+        ZOTERO_TAG: 'zotero-tag',
+        ZOTERO_NOTE: 'zotero-note',
+        ZITEM_ATTACHMENT: 'zitem-attachment',
+        CITATION_POOL: 'coolPool',
+        ZOTERO_UNFILED_ITEMS: 'zotero-unfiled-items',
+        ZOTERO_CONNECTOR_HOME: 'zotero-connector-home',
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-// Rename summary: setForceStop -> markForceStopRequested; COOL_POOL -> CITATION_POOL
+// Rename summary: abort sync handling and CITATION_POOL rename
 import {
 	declareIndexPlugin,
 	PropertyLocation,
@@ -11,7 +11,7 @@ import { citationFormats, powerupCodes } from './constants/constants';
 import { itemTypes } from './constants/zoteroItemSchema';
 import { autoSync } from './services/autoSync';
 import { registerIconCSS } from './services/iconCSS';
-import { markForceStopRequested } from './services/pluginIO';
+import { markAbortRequested } from './services/pluginIO';
 import { ensureZoteroLibraryRemExists } from './services/ensureUIPrettyZoteroRemExist';
 import { registerItemPowerups } from './services/zoteroSchemaToRemNote';
 import { ZoteroSyncManager } from './sync/zoteroSyncManager';
@@ -327,13 +327,14 @@ async function handleLibrarySwitch(plugin: RNPlugin) {
 	if (!selected) return;
 	const stored = (await plugin.storage.getSynced('syncedLibraryId')) as string | undefined;
 	if (stored && stored !== selected) {
-		await _deleteTaggedRems(plugin, [
-			powerupCodes.ZITEM,
-			powerupCodes.COLLECTION,
-			powerupCodes.ZOTERO_SYNCED_LIBRARY,
-			powerupCodes.CITATION_POOL,
-			powerupCodes.ZOTERO_UNFILED_ITEMS,
-		]);
+               await _deleteTaggedRems(plugin, [
+                       powerupCodes.ZITEM,
+                       powerupCodes.COLLECTION,
+                       powerupCodes.ZOTERO_SYNCED_LIBRARY,
+                       powerupCodes.CITATION_POOL,
+                       powerupCodes.ZOTERO_UNFILED_ITEMS,
+                       powerupCodes.ZOTERO_CONNECTOR_HOME,
+               ]);
 		await plugin.storage.setSynced('libraryRemMap', undefined);
 		await plugin.storage.setSynced('unfiledRemMap', undefined);
 		await plugin.storage.setSynced('zoteroLibraryRemId', undefined);
@@ -401,7 +402,7 @@ async function registerDebugCommands(plugin: RNPlugin) {
                 icon: '🛑',
                 keywords: 'zotero, stop, sync',
                 action: async () => {
-                        await markForceStopRequested(plugin);
+                       await markAbortRequested(plugin);
                 },
         });
 	await plugin.app.registerCommand({
@@ -469,13 +470,14 @@ async function registerDebugCommands(plugin: RNPlugin) {
 				)
 			) {
 				await plugin.storage.setSynced('zoteroDataMap', undefined);
-				await _deleteTaggedRems(plugin, [
-					powerupCodes.ZITEM,
-					powerupCodes.COLLECTION,
-					powerupCodes.ZOTERO_SYNCED_LIBRARY,
-					powerupCodes.CITATION_POOL,
-					powerupCodes.ZOTERO_UNFILED_ITEMS,
-				]);
+                               await _deleteTaggedRems(plugin, [
+                                       powerupCodes.ZITEM,
+                                       powerupCodes.COLLECTION,
+                                       powerupCodes.ZOTERO_SYNCED_LIBRARY,
+                                       powerupCodes.CITATION_POOL,
+                                       powerupCodes.ZOTERO_UNFILED_ITEMS,
+                                       powerupCodes.ZOTERO_CONNECTOR_HOME,
+                               ]);
 				await plugin.storage.setSynced('libraryRemMap', undefined);
 				await plugin.storage.setSynced('unfiledRemMap', undefined);
 				await plugin.storage.setSynced('zoteroLibraryRemId', undefined);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { itemTypes } from './constants/zoteroItemSchema';
 import { autoSync } from './services/autoSync';
 import { registerIconCSS } from './services/iconCSS';
 import { markForceStopRequested } from './services/pluginIO';
+import { ensureZoteroLibraryRemExists } from './services/ensureUIPrettyZoteroRemExist';
 import { registerItemPowerups } from './services/zoteroSchemaToRemNote';
 import { ZoteroSyncManager } from './sync/zoteroSyncManager';
 import { LogType, logMessage } from './utils/logging';
@@ -393,16 +394,16 @@ async function registerDebugCommands(plugin: RNPlugin) {
 			await zoteroSyncManager.sync();
 		},
 	});
-	await plugin.app.registerCommand({
-		name: 'Citationista Force Quit Syncing',
-		description: 'Force stop syncing with Zotero.',
-		id: 'force-stop-syncing',
-		icon: '🛑',
-		keywords: 'zotero, stop, sync',
-		action: async () => {
-			await markForceStopRequested(plugin);
-		},
-	});
+        await plugin.app.registerCommand({
+                name: 'Abort Citationista Sync',
+                description: 'Abort the current Zotero sync job.',
+                id: 'abort-sync-job',
+                icon: '🛑',
+                keywords: 'zotero, stop, sync',
+                action: async () => {
+                        await markForceStopRequested(plugin);
+                },
+        });
 	await plugin.app.registerCommand({
 		id: 'log-values',
 		name: 'citationista log values',
@@ -515,10 +516,11 @@ async function registerWidgets(plugin: RNPlugin) {
 }
 
 async function onActivate(plugin: RNPlugin) {
-	await registerSettings(plugin);
-	await registerPowerups(plugin);
-	await registerWidgets(plugin);
-	await handleLibrarySwitch(plugin);
+        await registerSettings(plugin);
+        await registerPowerups(plugin);
+        await ensureZoteroLibraryRemExists(plugin);
+        await registerWidgets(plugin);
+        await handleLibrarySwitch(plugin);
 
 	const multiInit = (await plugin.settings.getSetting('sync-multiple-libraries')) as
 		| boolean

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,48 +157,39 @@ async function registerPowerups(plugin: RNPlugin) {
 			],
 		},
 	});
-	await plugin.app.registerPowerup({
-		name: 'Citationista Pool',
-		code: powerupCodes.CITATION_POOL,
-		description: 'A pool of citationista rems.',
-		options: {
-			properties: [],
-		},
-	});
-	await plugin.app.registerPowerup({
-		name: 'Zotero Unfiled Items',
-		code: powerupCodes.ZOTERO_UNFILED_ITEMS,
-		description: 'Unfiled Items from Zotero.',
-		options: {
+        await plugin.app.registerPowerup({
+                name: 'Citationista Pool',
+                code: powerupCodes.CITATION_POOL,
+                description: 'A pool of citationista rems.',
+                options: {
+                        properties: [],
+                },
+        });
+        await plugin.app.registerPowerup({
+                name: 'Zotero Connector Home Page',
+                code: powerupCodes.ZOTERO_CONNECTOR_HOME,
+                description: 'Home page for the Zotero Connector.',
+                options: {
+                        properties: [],
+                },
+        });
+        await plugin.app.registerPowerup({
+                name: 'Zotero Unfiled Items',
+                code: powerupCodes.ZOTERO_UNFILED_ITEMS,
+                description: 'Unfiled Items from Zotero.',
+                options: {
 			properties: [],
 		},
 	});
 
-	await plugin.app.registerPowerup({
-		name: 'Zotero Library Sync Powerup',
-		code: powerupCodes.ZOTERO_SYNCED_LIBRARY,
-		description: 'Your Zotero library, synced with RemNote. :D',
-		options: {
-			properties: [
-				{
-					code: 'syncing',
-					name: 'Syncing',
-					onlyProgrammaticModifying: true,
-					hidden: false,
-					propertyType: PropertyType.CHECKBOX,
-					propertyLocation: PropertyLocation.ONLY_DOCUMENT,
-				},
-				{
-					code: 'progress',
-					name: 'Progress',
-					onlyProgrammaticModifying: true,
-					hidden: false,
-					propertyType: PropertyType.NUMBER,
-					propertyLocation: PropertyLocation.ONLY_DOCUMENT,
-				},
-			],
-		},
-	});
+        await plugin.app.registerPowerup({
+                name: 'Zotero Library Sync Powerup',
+                code: powerupCodes.ZOTERO_SYNCED_LIBRARY,
+                description: 'Your Zotero library, synced with RemNote. :D',
+                options: {
+                        properties: [],
+                },
+        });
 
 	await plugin.app.registerPowerup({
 		name: 'Zotero Item',
@@ -517,10 +508,10 @@ async function registerDebugCommands(plugin: RNPlugin) {
 }
 
 async function registerWidgets(plugin: RNPlugin) {
-	await plugin.app.registerWidget('syncStatusWidget', WidgetLocation.DocumentBelowTitle, {
-		dimensions: { height: 'auto', width: 300 },
-		powerupFilter: powerupCodes.ZOTERO_SYNCED_LIBRARY,
-	});
+        await plugin.app.registerWidget('syncStatusWidget', WidgetLocation.DocumentBelowTitle, {
+                dimensions: { height: 'auto', width: 300 },
+                powerupFilter: powerupCodes.ZOTERO_CONNECTOR_HOME,
+        });
 }
 
 async function onActivate(plugin: RNPlugin) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
 	PropertyLocation,
 	PropertyType,
 	type RNPlugin,
+	WidgetLocation,
 } from '@remnote/plugin-sdk';
 import { fetchLibraries } from './api/zotero';
 import { citationFormats, powerupCodes } from './constants/constants';
@@ -515,9 +516,17 @@ async function registerDebugCommands(plugin: RNPlugin) {
 	});
 }
 
+async function registerWidgets(plugin: RNPlugin) {
+	await plugin.app.registerWidget('syncStatusWidget', WidgetLocation.DocumentBelowTitle, {
+		dimensions: { height: 'auto', width: 300 },
+		powerupFilter: powerupCodes.ZOTERO_SYNCED_LIBRARY,
+	});
+}
+
 async function onActivate(plugin: RNPlugin) {
 	await registerSettings(plugin);
 	await registerPowerups(plugin);
+	await registerWidgets(plugin);
 	await handleLibrarySwitch(plugin);
 
 	const multiInit = (await plugin.settings.getSetting('sync-multiple-libraries')) as

--- a/src/services/ensureUIPrettyZoteroRemExist.ts
+++ b/src/services/ensureUIPrettyZoteroRemExist.ts
@@ -15,15 +15,21 @@ export async function ensureZoteroLibraryRemExists(plugin: RNPlugin) {
 		false
 	);
 
-	const zoteroLibraryRemId = await plugin.storage.getSynced('zoteroLibraryRemId');
-	if (zoteroLibraryRemId !== undefined) {
-		const doesRemExist = await plugin.rem.findOne(zoteroLibraryRemId as string);
-		if (doesRemExist !== undefined) {
-			await doesRemExist.setText(['Zotero Connector Home Page']);
-			logMessage(plugin, 'Zotero Connector Home Page already exists', LogType.Info, false);
-			return doesRemExist;
-		}
-	}
+        const zoteroLibraryRemId = await plugin.storage.getSynced('zoteroLibraryRemId');
+        if (zoteroLibraryRemId !== undefined) {
+                const doesRemExist = await plugin.rem.findOne(zoteroLibraryRemId as string);
+                if (doesRemExist !== undefined) {
+                        await doesRemExist.setText(['Zotero Connector Home Page']);
+                        if (!(await doesRemExist.hasPowerup(powerupCodes.ZOTERO_CONNECTOR_HOME))) {
+                                await doesRemExist.addPowerup(powerupCodes.ZOTERO_CONNECTOR_HOME);
+                        }
+                        if (await doesRemExist.hasPowerup(powerupCodes.ZOTERO_SYNCED_LIBRARY)) {
+                                await doesRemExist.removePowerup(powerupCodes.ZOTERO_SYNCED_LIBRARY);
+                        }
+                        logMessage(plugin, 'Zotero Connector Home Page already exists', LogType.Info, false);
+                        return doesRemExist;
+                }
+        }
 	await logMessage(plugin, 'Zotero Connector Home Page Ensured', LogType.Info, false);
 
 	const rem: Rem | undefined = await plugin.rem.createRem();
@@ -36,7 +42,6 @@ export async function ensureZoteroLibraryRemExists(plugin: RNPlugin) {
 
         await rem.setText(['Zotero Connector Home Page']);
         await rem.addPowerup(powerupCodes.ZOTERO_CONNECTOR_HOME);
-        await rem.addPowerup(powerupCodes.ZOTERO_SYNCED_LIBRARY);
         await rem.addPowerup(BuiltInPowerupCodes.AutoSort);
 
 	await rem.setIsDocument(true); // TODO: we want this to be a folder rem! https://linear.app/remnoteio/issue/ENG-25553/add-a-remsetisfolder-to-the-plugin-system

--- a/src/services/ensureUIPrettyZoteroRemExist.ts
+++ b/src/services/ensureUIPrettyZoteroRemExist.ts
@@ -15,16 +15,16 @@ export async function ensureZoteroLibraryRemExists(plugin: RNPlugin) {
 		false
 	);
 
-       const zoteroLibraryRemId = await plugin.storage.getSynced('zoteroLibraryRemId');
-       if (zoteroLibraryRemId !== undefined) {
-               const doesRemExist = await plugin.rem.findOne(zoteroLibraryRemId as string);
-               if (doesRemExist !== undefined) {
-                       await doesRemExist.setText(['Zotero Connector Home Page']);
-                       logMessage(plugin, 'Zotero Connector Home Page already exists', LogType.Info, false);
-                       return doesRemExist;
-               }
-       }
-       await logMessage(plugin, 'Zotero Connector Home Page Ensured', LogType.Info, false);
+	const zoteroLibraryRemId = await plugin.storage.getSynced('zoteroLibraryRemId');
+	if (zoteroLibraryRemId !== undefined) {
+		const doesRemExist = await plugin.rem.findOne(zoteroLibraryRemId as string);
+		if (doesRemExist !== undefined) {
+			await doesRemExist.setText(['Zotero Connector Home Page']);
+			logMessage(plugin, 'Zotero Connector Home Page already exists', LogType.Info, false);
+			return doesRemExist;
+		}
+	}
+	await logMessage(plugin, 'Zotero Connector Home Page Ensured', LogType.Info, false);
 
 	const rem: Rem | undefined = await plugin.rem.createRem();
 	if (rem === undefined) {
@@ -34,11 +34,10 @@ export async function ensureZoteroLibraryRemExists(plugin: RNPlugin) {
 
 	await plugin.storage.setSynced('zoteroLibraryRemId', rem._id);
 
-
-       await rem.setText(['Zotero Connector Home Page']);
-       await rem.addPowerup(powerupCodes.ZOTERO_SYNCED_LIBRARY);
-       await rem.setPowerupProperty(powerupCodes.ZOTERO_SYNCED_LIBRARY, 'progress', ['0']);
-       await rem.addPowerup(BuiltInPowerupCodes.AutoSort);
+	await rem.setText(['Zotero Connector Home Page']);
+	await rem.addPowerup(powerupCodes.ZOTERO_SYNCED_LIBRARY);
+	await rem.setPowerupProperty(powerupCodes.ZOTERO_SYNCED_LIBRARY, 'progress', ['0']);
+	await rem.addPowerup(BuiltInPowerupCodes.AutoSort);
 
 	await rem.setIsDocument(true); // TODO: we want this to be a folder rem! https://linear.app/remnoteio/issue/ENG-25553/add-a-remsetisfolder-to-the-plugin-system
 
@@ -59,52 +58,50 @@ export async function ensureZoteroLibraryRemExists(plugin: RNPlugin) {
 }
 
 export async function ensureSpecificLibraryRemExists(
-
-       plugin: RNPlugin,
-       library: { id: string; type: 'user' | 'group'; name: string }
+	plugin: RNPlugin,
+	library: { id: string; type: 'user' | 'group'; name: string }
 ): Promise<Rem | null> {
-       const key = `${library.type}:${library.id}`;
-       const map = (await plugin.storage.getSynced('libraryRemMap')) as
-               | Record<string, string>
-               | undefined;
-       const existingId = map?.[key];
-       if (existingId) {
-               const existing = await plugin.rem.findOne(existingId);
-               if (existing) return existing;
-       }
+	const key = `${library.type}:${library.id}`;
+	const map = (await plugin.storage.getSynced('libraryRemMap')) as
+		| Record<string, string>
+		| undefined;
+	const existingId = map?.[key];
+	if (existingId) {
+		const existing = await plugin.rem.findOne(existingId);
+		if (existing) return existing;
+	}
 
-       const root = await ensureZoteroLibraryRemExists(plugin);
-       const rem = await plugin.rem.createRem();
-       if (!rem) {
-               await logMessage(plugin, 'Failed to create Library Rem', LogType.Error, false);
-               return null;
-       }
-       await rem.setText([library.name || key]);
-       await rem.addPowerup(powerupCodes.ZOTERO_SYNCED_LIBRARY);
-       await rem.setPowerupProperty(powerupCodes.ZOTERO_SYNCED_LIBRARY, 'progress', ['0']);
-       if (root) {
-               await rem.setParent(root);
-       }
-       await plugin.storage.setSynced('libraryRemMap', { ...(map || {}), [key]: rem._id });
-       return rem;
+	const root = await ensureZoteroLibraryRemExists(plugin);
+	const rem = await plugin.rem.createRem();
+	if (!rem) {
+		await logMessage(plugin, 'Failed to create Library Rem', LogType.Error, false);
+		return null;
+	}
+	await rem.setText([library.name || key]);
+	await rem.addPowerup(powerupCodes.ZOTERO_SYNCED_LIBRARY);
+	await rem.setPowerupProperty(powerupCodes.ZOTERO_SYNCED_LIBRARY, 'progress', ['0']);
+	if (root) {
+		await rem.setParent(root);
+	}
+	await plugin.storage.setSynced('libraryRemMap', { ...(map || {}), [key]: rem._id });
+	return rem;
 }
 
 export async function ensureUnfiledItemsRemExists(
-       plugin: RNPlugin,
-       libraryKey: string
+	plugin: RNPlugin,
+	libraryKey: string
 ): Promise<void> {
-       const map = (await plugin.storage.getSynced('unfiledRemMap')) as
-               | Record<string, string>
-               | undefined;
-       const existingId = map?.[libraryKey];
-       if (existingId) {
-               const existingRem = await plugin.rem.findOne(existingId as string);
-               if (existingRem) {
-                       logMessage(plugin, '"Unfiled Items" Rem already exists', LogType.Info, false);
-                       return;
-               }
-       }
-
+	const map = (await plugin.storage.getSynced('unfiledRemMap')) as
+		| Record<string, string>
+		| undefined;
+	const existingId = map?.[libraryKey];
+	if (existingId) {
+		const existingRem = await plugin.rem.findOne(existingId as string);
+		if (existingRem) {
+			logMessage(plugin, '"Unfiled Items" Rem already exists', LogType.Info, false);
+			return;
+		}
+	}
 
 	// Create the "Unfiled Items" Rem
 	const unfiledRem = await plugin.rem.createRem();
@@ -113,13 +110,11 @@ export async function ensureUnfiledItemsRemExists(
 		return;
 	}
 
-
-        await unfiledRem.setText(['Unfiled Items']);
-        await unfiledRem.addPowerup(powerupCodes.ZOTERO_UNFILED_ITEMS);
-        const zoteroRem = await getZoteroLibraryRem(plugin, libraryKey);
-        if (zoteroRem) {
-                await unfiledRem.setParent(zoteroRem);
-
+	await unfiledRem.setText(['Unfiled Items']);
+	await unfiledRem.addPowerup(powerupCodes.ZOTERO_UNFILED_ITEMS);
+	const zoteroRem = await getZoteroLibraryRem(plugin, libraryKey);
+	if (zoteroRem) {
+		await unfiledRem.setParent(zoteroRem);
 	} else {
 		await logMessage(
 			plugin,
@@ -130,63 +125,61 @@ export async function ensureUnfiledItemsRemExists(
 		return;
 	}
 
-
-        await plugin.storage.setSynced('unfiledRemMap', {
-                ...(map || {}),
-                [libraryKey]: unfiledRem._id,
-        });
-        logMessage(plugin, 'Created "Unfiled Items" Rem', LogType.Info, false);
+	await plugin.storage.setSynced('unfiledRemMap', {
+		...(map || {}),
+		[libraryKey]: unfiledRem._id,
+	});
+	logMessage(plugin, 'Created "Unfiled Items" Rem', LogType.Info, false);
 }
 
 export async function getZoteroLibraryRem(
-       plugin: RNPlugin,
-       libraryKey?: string
+	plugin: RNPlugin,
+	libraryKey?: string
 ): Promise<Rem | null> {
-       if (libraryKey) {
-               const map = (await plugin.storage.getSynced('libraryRemMap')) as
-                       | Record<string, string>
-                       | undefined;
-               const remId = map?.[libraryKey];
-               if (remId) {
-                       const rem = await plugin.rem.findOne(remId);
-                       if (rem) return rem;
-               }
-               return null;
-       }
-       const zoteroLibraryPowerUpRem = await plugin.powerup.getPowerupByCode(
-               powerupCodes.ZOTERO_SYNCED_LIBRARY
-       );
-       if (!zoteroLibraryPowerUpRem) {
-               console.error('Zotero Library Power-Up not found!');
-               return null;
-       }
-       const zoteroLibraryRem = (await zoteroLibraryPowerUpRem.taggedRem())[0];
-       return zoteroLibraryRem || null;
+	if (libraryKey) {
+		const map = (await plugin.storage.getSynced('libraryRemMap')) as
+			| Record<string, string>
+			| undefined;
+		const remId = map?.[libraryKey];
+		if (remId) {
+			const rem = await plugin.rem.findOne(remId);
+			if (rem) return rem;
+		}
+		return null;
+	}
+	const zoteroLibraryPowerUpRem = await plugin.powerup.getPowerupByCode(
+		powerupCodes.ZOTERO_SYNCED_LIBRARY
+	);
+	if (!zoteroLibraryPowerUpRem) {
+		console.error('Zotero Library Power-Up not found!');
+		return null;
+	}
+	const zoteroLibraryRem = (await zoteroLibraryPowerUpRem.taggedRem())[0];
+	return zoteroLibraryRem || null;
 }
 
 export async function getUnfiledItemsRem(
-       plugin: RNPlugin,
-       libraryKey?: string
+	plugin: RNPlugin,
+	libraryKey?: string
 ): Promise<Rem | null> {
-       if (libraryKey) {
-               const map = (await plugin.storage.getSynced('unfiledRemMap')) as
-                       | Record<string, string>
-                       | undefined;
-               const remId = map?.[libraryKey];
-               if (remId) {
-                       const rem = await plugin.rem.findOne(remId);
-                       if (rem) return rem;
-               }
-               return null;
-       }
-       const unfiledZoteroItemsPowerup = await plugin.powerup.getPowerupByCode(
-               powerupCodes.ZOTERO_UNFILED_ITEMS
-       );
-       if (!unfiledZoteroItemsPowerup) {
-               console.error('Unfiled Power-Up not found!');
-               return null;
-       }
-       const firstUnfiledZoteroItem = (await unfiledZoteroItemsPowerup.taggedRem())[0];
-       return firstUnfiledZoteroItem || null;
-
+	if (libraryKey) {
+		const map = (await plugin.storage.getSynced('unfiledRemMap')) as
+			| Record<string, string>
+			| undefined;
+		const remId = map?.[libraryKey];
+		if (remId) {
+			const rem = await plugin.rem.findOne(remId);
+			if (rem) return rem;
+		}
+		return null;
+	}
+	const unfiledZoteroItemsPowerup = await plugin.powerup.getPowerupByCode(
+		powerupCodes.ZOTERO_UNFILED_ITEMS
+	);
+	if (!unfiledZoteroItemsPowerup) {
+		console.error('Unfiled Power-Up not found!');
+		return null;
+	}
+	const firstUnfiledZoteroItem = (await unfiledZoteroItemsPowerup.taggedRem())[0];
+	return firstUnfiledZoteroItem || null;
 }

--- a/src/services/ensureUIPrettyZoteroRemExist.ts
+++ b/src/services/ensureUIPrettyZoteroRemExist.ts
@@ -26,6 +26,15 @@ export async function ensureZoteroLibraryRemExists(plugin: RNPlugin) {
                         if (await doesRemExist.hasPowerup(powerupCodes.ZOTERO_SYNCED_LIBRARY)) {
                                 await doesRemExist.removePowerup(powerupCodes.ZOTERO_SYNCED_LIBRARY);
                         }
+                        const powerRem = await plugin.powerup.getPowerupByCode(powerupCodes.ZOTERO_CONNECTOR_HOME);
+                        const tagged = powerRem ? await powerRem.taggedRem() : [];
+                        if (tagged.length > 1) {
+                                for (const extra of tagged) {
+                                        if (extra._id !== doesRemExist._id) {
+                                                await extra.removePowerup(powerupCodes.ZOTERO_CONNECTOR_HOME);
+                                        }
+                                }
+                        }
                         logMessage(plugin, 'Zotero Connector Home Page already exists', LogType.Info, false);
                         return doesRemExist;
                 }

--- a/src/services/ensureUIPrettyZoteroRemExist.ts
+++ b/src/services/ensureUIPrettyZoteroRemExist.ts
@@ -34,10 +34,10 @@ export async function ensureZoteroLibraryRemExists(plugin: RNPlugin) {
 
 	await plugin.storage.setSynced('zoteroLibraryRemId', rem._id);
 
-	await rem.setText(['Zotero Connector Home Page']);
-	await rem.addPowerup(powerupCodes.ZOTERO_SYNCED_LIBRARY);
-	await rem.setPowerupProperty(powerupCodes.ZOTERO_SYNCED_LIBRARY, 'progress', ['0']);
-	await rem.addPowerup(BuiltInPowerupCodes.AutoSort);
+        await rem.setText(['Zotero Connector Home Page']);
+        await rem.addPowerup(powerupCodes.ZOTERO_CONNECTOR_HOME);
+        await rem.addPowerup(powerupCodes.ZOTERO_SYNCED_LIBRARY);
+        await rem.addPowerup(BuiltInPowerupCodes.AutoSort);
 
 	await rem.setIsDocument(true); // TODO: we want this to be a folder rem! https://linear.app/remnoteio/issue/ENG-25553/add-a-remsetisfolder-to-the-plugin-system
 
@@ -77,12 +77,11 @@ export async function ensureSpecificLibraryRemExists(
 		await logMessage(plugin, 'Failed to create Library Rem', LogType.Error, false);
 		return null;
 	}
-	await rem.setText([library.name || key]);
-	await rem.addPowerup(powerupCodes.ZOTERO_SYNCED_LIBRARY);
-	await rem.setPowerupProperty(powerupCodes.ZOTERO_SYNCED_LIBRARY, 'progress', ['0']);
-	if (root) {
-		await rem.setParent(root);
-	}
+        await rem.setText([library.name || key]);
+        await rem.addPowerup(powerupCodes.ZOTERO_SYNCED_LIBRARY);
+        if (root) {
+                await rem.setParent(root);
+        }
 	await plugin.storage.setSynced('libraryRemMap', { ...(map || {}), [key]: rem._id });
 	return rem;
 }
@@ -147,13 +146,13 @@ export async function getZoteroLibraryRem(
 		}
 		return null;
 	}
-	const zoteroLibraryPowerUpRem = await plugin.powerup.getPowerupByCode(
-		powerupCodes.ZOTERO_SYNCED_LIBRARY
-	);
-	if (!zoteroLibraryPowerUpRem) {
-		console.error('Zotero Library Power-Up not found!');
-		return null;
-	}
+        const zoteroLibraryPowerUpRem = await plugin.powerup.getPowerupByCode(
+                powerupCodes.ZOTERO_CONNECTOR_HOME
+        );
+        if (!zoteroLibraryPowerUpRem) {
+                console.error('Zotero Library Power-Up not found!');
+                return null;
+        }
 	const zoteroLibraryRem = (await zoteroLibraryPowerUpRem.taggedRem())[0];
 	return zoteroLibraryRem || null;
 }

--- a/src/services/pluginIO.ts
+++ b/src/services/pluginIO.ts
@@ -6,15 +6,16 @@ export async function markForceStopRequested(plugin: RNPlugin) {
 }
 
 export async function checkForceStopFlag(plugin: RNPlugin) {
-	const isBeingStopped = await plugin.storage.getSession('isBeingStopped');
-	switch (isBeingStopped) {
-		case undefined:
-		case false:
-			return false;
-		case true:
-			console.warn('Force stop detected. Stopping sync.');
-			await plugin.app.toast('Force stop detected. Stopping sync.');
-			await plugin.storage.setSession('isBeingStopped', false);
-			return true;
-	}
+        const isBeingStopped = await plugin.storage.getSession('isBeingStopped');
+        switch (isBeingStopped) {
+                case undefined:
+                case false:
+                        return false;
+                case true:
+                        console.warn('Force stop detected. Stopping sync.');
+                        await plugin.app.toast('Force stop detected. Stopping sync.');
+                        await plugin.storage.setSession('isBeingStopped', false);
+                        return true;
+        }
+        return false;
 }

--- a/src/services/pluginIO.ts
+++ b/src/services/pluginIO.ts
@@ -1,21 +1,20 @@
-// Rename summary: setForceStop -> markForceStopRequested; checkForForceStop -> checkForceStopFlag
 import type { RNPlugin } from '@remnote/plugin-sdk';
 
-export async function markForceStopRequested(plugin: RNPlugin) {
-	await plugin.storage.setSession('isBeingStopped', true);
+export async function markAbortRequested(plugin: RNPlugin) {
+       await plugin.storage.setSession('abortRequested', true);
 }
 
-export async function checkForceStopFlag(plugin: RNPlugin) {
-        const isBeingStopped = await plugin.storage.getSession('isBeingStopped');
-        switch (isBeingStopped) {
-                case undefined:
-                case false:
-                        return false;
-                case true:
-                        console.warn('Force stop detected. Stopping sync.');
-                        await plugin.app.toast('Force stop detected. Stopping sync.');
-                        await plugin.storage.setSession('isBeingStopped', false);
-                        return true;
-        }
-        return false;
+export async function checkAbortFlag(plugin: RNPlugin) {
+       const abortRequested = await plugin.storage.getSession('abortRequested');
+       switch (abortRequested) {
+               case undefined:
+               case false:
+                       return false;
+               case true:
+                       console.warn('Abort detected. Stopping sync.');
+                       await plugin.app.toast('Abort detected. Stopping sync.');
+                       await plugin.storage.setSession('abortRequested', false);
+                       return true;
+       }
+       return false;
 }

--- a/src/sync/treeBuilder.ts
+++ b/src/sync/treeBuilder.ts
@@ -19,13 +19,9 @@ export class TreeBuilder {
                 this.plugin = plugin;
         }
 
-        setLibraryKey(key: string) {
-                this.libraryKey = key;
-        }
-
-	setLibraryKey(key: string) {
-		this.libraryKey = key;
-	}
+       setLibraryKey(key: string) {
+               this.libraryKey = key;
+       }
 
 	/**
 	 * Initializes the node cache by fetching all Rems tagged with specific power-ups

--- a/src/sync/zoteroSyncManager.ts
+++ b/src/sync/zoteroSyncManager.ts
@@ -2,12 +2,10 @@
 import type { RNPlugin } from '@remnote/plugin-sdk';
 
 import { ZoteroAPI, fetchLibraries, type ZoteroLibraryInfo } from '../api/zotero';
-import { powerupCodes } from '../constants/constants';
 import {
        ensureUnfiledItemsRemExists,
        ensureZoteroLibraryRemExists,
        ensureSpecificLibraryRemExists,
-       getZoteroLibraryRem,
 
 } from '../services/ensureUIPrettyZoteroRemExist';
 import type { ChangeSet, Collection, Item } from '../types/types';
@@ -17,6 +15,7 @@ import { mergeUpdatedItems } from './mergeUpdatedItems';
 import { ZoteroPropertyHydrator } from './propertyHydrator';
 import { TreeBuilder } from './treeBuilder';
 import { tryAcquire, release } from './syncLock';
+import { checkForceStopFlag } from '../services/pluginIO';
 
 export class ZoteroSyncManager {
 	private plugin: RNPlugin;
@@ -33,15 +32,22 @@ export class ZoteroSyncManager {
                 this.propertyHydrator = new ZoteroPropertyHydrator(plugin);
         }
 
-       private async updateProgress(key: string, value: number) {
-               const rem = await getZoteroLibraryRem(this.plugin, key);
-               if (rem) {
-                       await rem.setPowerupProperty(
-                               powerupCodes.ZOTERO_SYNCED_LIBRARY,
-                               'progress',
-                               [String(value)]
-                       );
+       private async updateProgress(value: number) {
+               await this.plugin.storage.setSession('syncProgress', value);
+       }
+
+       private async setSyncingStatus(active: boolean) {
+               await this.plugin.storage.setSession('syncing', active);
+       }
+
+       private async checkAbort(): Promise<boolean> {
+               const stop = await checkForceStopFlag(this.plugin);
+               if (stop) {
+                       await this.setSyncingStatus(false);
+                       await this.updateProgress(0);
+                       await logMessage(this.plugin, 'Sync aborted', LogType.Info, false);
                }
+               return stop;
        }
 
        async sync(): Promise<void> {
@@ -94,9 +100,12 @@ export class ZoteroSyncManager {
                await ensureSpecificLibraryRemExists(this.plugin, library);
                await ensureUnfiledItemsRemExists(this.plugin, key);
 
-               await this.updateProgress(key, 0);
+               await this.setSyncingStatus(true);
+               await this.updateProgress(0);
+               if (await this.checkAbort()) return;
 
-               await this.updateProgress(key, 0.1);
+               await this.updateProgress(0.1);
+               if (await this.checkAbort()) return;
 
                // 2. Fetch current data from Zotero.
                const currentData = await this.api.fetchLibraryData(library.type, library.id);
@@ -125,7 +134,8 @@ export class ZoteroSyncManager {
 
 		// 4. Initialize node cache for the current Rem tree.
                this.treeBuilder.setLibraryKey(key);
-               await this.updateProgress(key, 0.2);
+               await this.updateProgress(0.2);
+               if (await this.checkAbort()) return;
                await this.treeBuilder.initializeNodeCache();
 
 
@@ -135,15 +145,14 @@ export class ZoteroSyncManager {
                // 6. For each updated item, merge local modifications with remote data,
                //    using the previous sync (shadow) data as the base.
                await mergeUpdatedItems(
-                        this.plugin,
-                        changes,
-                        prevData.items,
-                        this.treeBuilder.getNodeCache()
+                       this.plugin,
+                       changes,
+                       prevData.items,
+                       this.treeBuilder.getNodeCache()
                );
 
-               await this.updateProgress(key, 0.4);
-
-		await this.updateProgress(key, 0.4);
+               await this.updateProgress(0.4);
+               if (await this.checkAbort()) return;
 
 		// 7. Apply structural changes to update the Rem tree. (this step and beyond actually modify the user's KB.)
 		console.log('Changes detected:', changes);
@@ -154,9 +163,8 @@ export class ZoteroSyncManager {
                        await this.propertyHydrator.hydrateItemAndCollectionProperties(changes);
                }
 
-               await this.updateProgress(key, 0.7);
-
-		await this.updateProgress(key, 0.7);
+               await this.updateProgress(0.7);
+               if (await this.checkAbort()) return;
 
 		// 9. Save the current data as the new shadow copy for future syncs.
 		const serializableData = {
@@ -176,9 +184,8 @@ export class ZoteroSyncManager {
                };
                await this.plugin.storage.setSynced('zoteroDataMap', updatedMap);
 
-               await this.updateProgress(key, 1);
-
-
+               await this.updateProgress(1);
+               await this.setSyncingStatus(false);
                logMessage(this.plugin, 'Sync complete!', LogType.Info, true);
-	}
+        }
 }

--- a/src/sync/zoteroSyncManager.ts
+++ b/src/sync/zoteroSyncManager.ts
@@ -64,11 +64,12 @@ export class ZoteroSyncManager {
                try {
                        const multi = await this.plugin.settings.getSetting('sync-multiple-libraries');
                        if (multi) {
-                               const libs = await fetchLibraries(this.plugin);
-                               for (const lib of libs) {
-                                       await this.syncLibrary(lib);
-                               }
-                               return;
+                       const libs = await fetchLibraries(this.plugin);
+                       for (const lib of libs) {
+                               await this.syncLibrary(lib);
+                       }
+                       await logMessage(this.plugin, 'Sync complete!', LogType.Info, true);
+                       return;
                        }
 
                const selected = (await this.plugin.settings.getSetting('zotero-library-id')) as
@@ -87,6 +88,7 @@ export class ZoteroSyncManager {
                if (!library) return;
 
                await this.syncLibrary(library);
+               await logMessage(this.plugin, 'Sync complete!', LogType.Info, true);
                } finally {
                        release();
                }
@@ -189,6 +191,6 @@ export class ZoteroSyncManager {
                await this.updateProgress(1);
                await this.setSyncingStatus(false);
                await this.plugin.storage.setSession('syncStartTime', undefined);
-               logMessage(this.plugin, 'Sync complete!', LogType.Info, true);
+               await logMessage(this.plugin, 'Library sync complete', LogType.Info, false);
        }
 }

--- a/src/sync/zoteroSyncManager.ts
+++ b/src/sync/zoteroSyncManager.ts
@@ -15,7 +15,7 @@ import { mergeUpdatedItems } from './mergeUpdatedItems';
 import { ZoteroPropertyHydrator } from './propertyHydrator';
 import { TreeBuilder } from './treeBuilder';
 import { tryAcquire, release } from './syncLock';
-import { checkForceStopFlag } from '../services/pluginIO';
+import { checkAbortFlag } from '../services/pluginIO';
 
 export class ZoteroSyncManager {
 	private plugin: RNPlugin;
@@ -41,7 +41,7 @@ export class ZoteroSyncManager {
        }
 
        private async checkAbort(): Promise<boolean> {
-               const stop = await checkForceStopFlag(this.plugin);
+               const stop = await checkAbortFlag(this.plugin);
                if (stop) {
                        await this.setSyncingStatus(false);
                        await this.updateProgress(0);

--- a/src/sync/zoteroSyncManager.ts
+++ b/src/sync/zoteroSyncManager.ts
@@ -45,6 +45,7 @@ export class ZoteroSyncManager {
                if (stop) {
                        await this.setSyncingStatus(false);
                        await this.updateProgress(0);
+                       await this.plugin.storage.setSession('syncStartTime', undefined);
                        await logMessage(this.plugin, 'Sync aborted', LogType.Info, false);
                }
                return stop;
@@ -101,6 +102,7 @@ export class ZoteroSyncManager {
                await ensureUnfiledItemsRemExists(this.plugin, key);
 
                await this.setSyncingStatus(true);
+               await this.plugin.storage.setSession('syncStartTime', new Date().toISOString());
                await this.updateProgress(0);
                if (await this.checkAbort()) return;
 
@@ -186,6 +188,7 @@ export class ZoteroSyncManager {
 
                await this.updateProgress(1);
                await this.setSyncingStatus(false);
+               await this.plugin.storage.setSession('syncStartTime', undefined);
                logMessage(this.plugin, 'Sync complete!', LogType.Info, true);
-        }
+       }
 }

--- a/src/widgets/syncStatusWidget.tsx
+++ b/src/widgets/syncStatusWidget.tsx
@@ -1,6 +1,6 @@
 import { type Rem, renderWidget, usePlugin } from '@remnote/plugin-sdk';
 import { useCallback, useEffect, useState } from 'react';
-import { markForceStopRequested } from '../services/pluginIO';
+import { markAbortRequested } from '../services/pluginIO';
 import { ZoteroSyncManager } from '../sync/zoteroSyncManager';
 
 interface SyncStatus {
@@ -102,7 +102,7 @@ function SyncStatusWidget() {
 	// Handle abort sync
 	const handleAbortSync = async () => {
 		try {
-			await markForceStopRequested(plugin);
+                       await markAbortRequested(plugin);
 			await plugin.app.toast('Sync abort requested');
 			await updateSyncStatus();
 		} catch (error) {

--- a/src/widgets/syncStatusWidget.tsx
+++ b/src/widgets/syncStatusWidget.tsx
@@ -1,0 +1,239 @@
+import { type Rem, renderWidget, usePlugin } from '@remnote/plugin-sdk';
+import { useCallback, useEffect, useState } from 'react';
+import { powerupCodes } from '../constants/constants';
+import { markForceStopRequested } from '../services/pluginIO';
+import { ZoteroSyncManager } from '../sync/zoteroSyncManager';
+
+interface SyncStatus {
+	isActive: boolean;
+	progress: number;
+	lastSyncTime?: Date;
+	libraryName?: string;
+}
+
+function SyncStatusWidget() {
+	const plugin = usePlugin();
+	const [syncStatus, setSyncStatus] = useState<SyncStatus>({
+		isActive: false,
+		progress: 0,
+	});
+	const [isProcessing, setIsProcessing] = useState(false);
+
+	// Get current Zotero library Rem with ZOTERO_SYNCED_LIBRARY powerup
+	const getCurrentLibraryRem = useCallback(async (): Promise<Rem | null> => {
+		const syncedLibraryId = await plugin.storage.getSynced('syncedLibraryId');
+		if (!syncedLibraryId) return null;
+
+		const libraryRemMap = (await plugin.storage.getSynced('libraryRemMap')) as
+			| Record<string, string>
+			| undefined;
+		const remId = libraryRemMap?.[syncedLibraryId as string];
+
+		if (remId) {
+			const rem = await plugin.rem.findOne(remId);
+			return rem || null;
+		}
+
+		return null;
+	}, [plugin.storage, plugin.rem]);
+
+	// Update sync status from storage
+	const updateSyncStatus = useCallback(async () => {
+		try {
+			const libraryRem = await getCurrentLibraryRem();
+			if (!libraryRem) {
+				setSyncStatus({ isActive: false, progress: 0 });
+				return;
+			}
+
+			const progressValue = await libraryRem.getPowerupProperty(
+				powerupCodes.ZOTERO_SYNCED_LIBRARY,
+				'progress'
+			);
+			const progress = progressValue?.[0] ? parseFloat(progressValue[0] as string) : 0;
+
+			const isSyncing = await libraryRem.getPowerupProperty(
+				powerupCodes.ZOTERO_SYNCED_LIBRARY,
+				'syncing'
+			);
+			const isActive = (isSyncing?.[0] as string) === 'true';
+
+			// Get library name from rem text
+			const libraryText = libraryRem.text;
+			const libraryName = (libraryText?.[0] as string) || 'Zotero Library';
+
+			// Get last sync time from storage
+			const lastSyncString = await plugin.storage.getSynced('lastSyncTime');
+			const lastSyncTime = lastSyncString ? new Date(lastSyncString as string) : undefined;
+
+			setSyncStatus({
+				isActive,
+				progress,
+				lastSyncTime,
+				libraryName,
+			});
+		} catch (error) {
+			console.error('Error updating sync status:', error);
+		}
+	}, [getCurrentLibraryRem, plugin.storage]);
+
+	// Handle sync now button
+	const handleSyncNow = async () => {
+		if (isProcessing) return;
+
+		setIsProcessing(true);
+		try {
+			const syncManager = new ZoteroSyncManager(plugin);
+			await syncManager.sync();
+
+			// Update last sync time
+			await plugin.storage.setSynced('lastSyncTime', new Date().toISOString());
+			await updateSyncStatus();
+		} catch (error) {
+			console.error('Sync failed:', error);
+			const message = error instanceof Error ? error.message : 'Unknown error';
+			await plugin.app.toast('Sync failed: ' + message);
+		} finally {
+			setIsProcessing(false);
+		}
+	};
+
+	// Handle abort sync
+	const handleAbortSync = async () => {
+		try {
+			await markForceStopRequested(plugin);
+			await plugin.app.toast('Sync abort requested');
+			await updateSyncStatus();
+		} catch (error) {
+			console.error('Error aborting sync:', error);
+		}
+	};
+
+	// Format last sync time
+	const formatLastSync = (date: Date): string => {
+		const now = new Date();
+		const diffInMinutes = Math.floor((now.getTime() - date.getTime()) / (1000 * 60));
+
+		if (diffInMinutes < 1) return 'just now';
+		if (diffInMinutes === 1) return '1 minute ago';
+		if (diffInMinutes < 60) return `${diffInMinutes} minutes ago`;
+
+		const diffInHours = Math.floor(diffInMinutes / 60);
+		if (diffInHours === 1) return '1 hour ago';
+		if (diffInHours < 24) return `${diffInHours} hours ago`;
+
+		const diffInDays = Math.floor(diffInHours / 24);
+		if (diffInDays === 1) return '1 day ago';
+		return `${diffInDays} days ago`;
+	};
+
+	// Set up polling for sync status updates
+	useEffect(() => {
+		updateSyncStatus();
+
+		const interval = setInterval(updateSyncStatus, 2000); // Update every 2 seconds
+
+		return () => clearInterval(interval);
+	}, [updateSyncStatus]);
+
+	const progressPercentage = Math.min(100, Math.max(0, syncStatus.progress * 100));
+
+	return (
+		<div className="fixed left-1/2 -translate-x-1/2 bottom-8 z-50 w-full max-w-md pointer-events-none">
+			<div className="pointer-events-auto bg-gradient-to-br from-blue-50/90 to-white/90 dark:from-gray-900/90 dark:to-gray-800/90 rounded-2xl shadow-2xl border border-blue-200 dark:border-blue-700 px-8 py-6 flex flex-col gap-4 animate-fade-in">
+				<div className="flex items-center gap-3 mb-2">
+					<div className="flex-shrink-0 w-10 h-10 bg-blue-100 dark:bg-blue-900 rounded-full flex items-center justify-center">
+						<svg
+							className="w-6 h-6 text-blue-600 dark:text-blue-300"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							viewBox="0 0 24 24"
+						>
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+							/>
+						</svg>
+					</div>
+					<div>
+						<h3 className="text-lg font-bold text-gray-900 dark:text-gray-100">
+							Zotero Sync Status
+						</h3>
+						{syncStatus.libraryName && (
+							<p className="text-xs text-blue-700 dark:text-blue-300 font-medium">
+								{syncStatus.libraryName}
+							</p>
+						)}
+					</div>
+				</div>
+
+				{/* Progress Bar */}
+				<div className="mb-2">
+					<div className="flex justify-between items-center mb-1">
+						<span className="text-xs text-gray-600 dark:text-gray-400">
+							{syncStatus.isActive ? 'Syncing...' : 'Ready'}
+						</span>
+						<span className="text-xs text-gray-600 dark:text-gray-400">
+							{Math.round(progressPercentage)}%
+						</span>
+					</div>
+					<div className="w-full bg-blue-100 dark:bg-blue-900 rounded-full h-3 overflow-hidden">
+						<div
+							className={`h-3 rounded-full transition-all duration-500 ${
+								syncStatus.isActive ? 'bg-blue-500 animate-pulse' : 'bg-green-500'
+							}`}
+							style={{ width: `${progressPercentage}%` }}
+						/>
+					</div>
+				</div>
+
+				{/* Last Sync Info */}
+				{syncStatus.lastSyncTime && (
+					<div className="mb-2 text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1">
+						<svg
+							className="w-4 h-4 text-blue-400"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							viewBox="0 0 24 24"
+						>
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+							/>
+						</svg>
+						<span>Last synced: {formatLastSync(syncStatus.lastSyncTime)}</span>
+					</div>
+				)}
+
+				{/* Action Buttons */}
+				<div className="flex gap-3 mt-2">
+					{syncStatus.isActive ? (
+						<button
+							type="button"
+							onClick={handleAbortSync}
+							className="flex-1 px-4 py-2 text-xs font-semibold text-white bg-red-600 hover:bg-red-700 disabled:bg-red-400 rounded-lg shadow transition-colors focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-2"
+							disabled={isProcessing}
+						>
+							Abort Sync
+						</button>
+					) : (
+						<button
+							type="button"
+							onClick={handleSyncNow}
+							className="flex-1 px-4 py-2 text-xs font-semibold text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 rounded-lg shadow transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
+							disabled={isProcessing}
+						>
+							{isProcessing ? 'Syncing...' : 'Sync Now'}
+						</button>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+renderWidget(SyncStatusWidget);

--- a/src/widgets/syncStatusWidget.tsx
+++ b/src/widgets/syncStatusWidget.tsx
@@ -1,6 +1,5 @@
 import { type Rem, renderWidget, usePlugin } from '@remnote/plugin-sdk';
 import { useCallback, useEffect, useState } from 'react';
-import { powerupCodes } from '../constants/constants';
 import { markForceStopRequested } from '../services/pluginIO';
 import { ZoteroSyncManager } from '../sync/zoteroSyncManager';
 
@@ -19,7 +18,7 @@ function SyncStatusWidget() {
 	});
 	const [isProcessing, setIsProcessing] = useState(false);
 
-	// Get current Zotero library Rem with ZOTERO_SYNCED_LIBRARY powerup
+        // Get current Zotero library Rem
 	const getCurrentLibraryRem = useCallback(async (): Promise<Rem | null> => {
 		const syncedLibraryId = await plugin.storage.getSynced('syncedLibraryId');
 		if (!syncedLibraryId) return null;
@@ -37,45 +36,36 @@ function SyncStatusWidget() {
 		return null;
 	}, [plugin.storage, plugin.rem]);
 
-	// Update sync status from storage
-	const updateSyncStatus = useCallback(async () => {
-		try {
-			const libraryRem = await getCurrentLibraryRem();
-			if (!libraryRem) {
-				setSyncStatus({ isActive: false, progress: 0 });
-				return;
-			}
+        // Update sync status from storage
+        const updateSyncStatus = useCallback(async () => {
+                try {
+                        const libraryRem = await getCurrentLibraryRem();
+                        if (!libraryRem) {
+                                setSyncStatus({ isActive: false, progress: 0 });
+                                return;
+                        }
 
-			const progressValue = await libraryRem.getPowerupProperty(
-				powerupCodes.ZOTERO_SYNCED_LIBRARY,
-				'progress'
-			);
-			const progress = progressValue?.[0] ? parseFloat(progressValue[0] as string) : 0;
+                        const progress = ((await plugin.storage.getSession('syncProgress')) as number) || 0;
+                        const isActive = ((await plugin.storage.getSession('syncing')) as boolean) || false;
 
-			const isSyncing = await libraryRem.getPowerupProperty(
-				powerupCodes.ZOTERO_SYNCED_LIBRARY,
-				'syncing'
-			);
-			const isActive = (isSyncing?.[0] as string) === 'true';
+                        // Get library name from rem text
+                        const libraryText = libraryRem.text;
+                        const libraryName = (libraryText?.[0] as string) || 'Zotero Library';
 
-			// Get library name from rem text
-			const libraryText = libraryRem.text;
-			const libraryName = (libraryText?.[0] as string) || 'Zotero Library';
+                        // Get last sync time from storage
+                        const lastSyncString = await plugin.storage.getSynced('lastSyncTime');
+                        const lastSyncTime = lastSyncString ? new Date(lastSyncString as string) : undefined;
 
-			// Get last sync time from storage
-			const lastSyncString = await plugin.storage.getSynced('lastSyncTime');
-			const lastSyncTime = lastSyncString ? new Date(lastSyncString as string) : undefined;
-
-			setSyncStatus({
-				isActive,
-				progress,
-				lastSyncTime,
-				libraryName,
-			});
-		} catch (error) {
-			console.error('Error updating sync status:', error);
-		}
-	}, [getCurrentLibraryRem, plugin.storage]);
+                        setSyncStatus({
+                                isActive,
+                                progress,
+                                lastSyncTime,
+                                libraryName,
+                        });
+                } catch (error) {
+                        console.error('Error updating sync status:', error);
+                }
+        }, [getCurrentLibraryRem, plugin.storage]);
 
 	// Handle sync now button
 	const handleSyncNow = async () => {
@@ -138,102 +128,46 @@ function SyncStatusWidget() {
 
 	const progressPercentage = Math.min(100, Math.max(0, syncStatus.progress * 100));
 
-	return (
-		<div className="fixed left-1/2 -translate-x-1/2 bottom-8 z-50 w-full max-w-md pointer-events-none">
-			<div className="pointer-events-auto bg-gradient-to-br from-blue-50/90 to-white/90 dark:from-gray-900/90 dark:to-gray-800/90 rounded-2xl shadow-2xl border border-blue-200 dark:border-blue-700 px-8 py-6 flex flex-col gap-4 animate-fade-in">
-				<div className="flex items-center gap-3 mb-2">
-					<div className="flex-shrink-0 w-10 h-10 bg-blue-100 dark:bg-blue-900 rounded-full flex items-center justify-center">
-						<svg
-							className="w-6 h-6 text-blue-600 dark:text-blue-300"
-							fill="none"
-							stroke="currentColor"
-							strokeWidth="2"
-							viewBox="0 0 24 24"
-						>
-							<path
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-							/>
-						</svg>
-					</div>
-					<div>
-						<h3 className="text-lg font-bold text-gray-900 dark:text-gray-100">
-							Zotero Sync Status
-						</h3>
-						{syncStatus.libraryName && (
-							<p className="text-xs text-blue-700 dark:text-blue-300 font-medium">
-								{syncStatus.libraryName}
-							</p>
-						)}
-					</div>
-				</div>
-
-				{/* Progress Bar */}
-				<div className="mb-2">
-					<div className="flex justify-between items-center mb-1">
-						<span className="text-xs text-gray-600 dark:text-gray-400">
-							{syncStatus.isActive ? 'Syncing...' : 'Ready'}
-						</span>
-						<span className="text-xs text-gray-600 dark:text-gray-400">
-							{Math.round(progressPercentage)}%
-						</span>
-					</div>
-					<div className="w-full bg-blue-100 dark:bg-blue-900 rounded-full h-3 overflow-hidden">
-						<div
-							className={`h-3 rounded-full transition-all duration-500 ${
-								syncStatus.isActive ? 'bg-blue-500 animate-pulse' : 'bg-green-500'
-							}`}
-							style={{ width: `${progressPercentage}%` }}
-						/>
-					</div>
-				</div>
-
-				{/* Last Sync Info */}
-				{syncStatus.lastSyncTime && (
-					<div className="mb-2 text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1">
-						<svg
-							className="w-4 h-4 text-blue-400"
-							fill="none"
-							stroke="currentColor"
-							strokeWidth="2"
-							viewBox="0 0 24 24"
-						>
-							<path
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-							/>
-						</svg>
-						<span>Last synced: {formatLastSync(syncStatus.lastSyncTime)}</span>
-					</div>
-				)}
-
-				{/* Action Buttons */}
-				<div className="flex gap-3 mt-2">
-					{syncStatus.isActive ? (
-						<button
-							type="button"
-							onClick={handleAbortSync}
-							className="flex-1 px-4 py-2 text-xs font-semibold text-white bg-red-600 hover:bg-red-700 disabled:bg-red-400 rounded-lg shadow transition-colors focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-2"
-							disabled={isProcessing}
-						>
-							Abort Sync
-						</button>
-					) : (
-						<button
-							type="button"
-							onClick={handleSyncNow}
-							className="flex-1 px-4 py-2 text-xs font-semibold text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 rounded-lg shadow transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
-							disabled={isProcessing}
-						>
-							{isProcessing ? 'Syncing...' : 'Sync Now'}
-						</button>
-					)}
-				</div>
-			</div>
-		</div>
-	);
+        return (
+                <div className="fixed left-1/2 -translate-x-1/2 bottom-8 z-50 pointer-events-none">
+                        <div className="pointer-events-auto bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-md p-4 flex items-center gap-4">
+                                <button
+                                        type="button"
+                                        onClick={syncStatus.isActive ? handleAbortSync : handleSyncNow}
+                                        className={`w-12 h-12 rounded-full text-white flex items-center justify-center transition-colors ${
+                                                syncStatus.isActive
+                                                        ? 'bg-red-600 hover:bg-red-700'
+                                                        : 'bg-blue-600 hover:bg-blue-700'
+                                        }`}
+                                        disabled={isProcessing}
+                                >
+                                        {syncStatus.isActive ? '⏹' : '▶'}
+                                </button>
+                                <div className="flex-1">
+                                        <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2 overflow-hidden">
+                                                <div
+                                                        className="bg-blue-500 h-2 rounded-full transition-all"
+                                                        style={{ width: `${progressPercentage}%` }}
+                                                />
+                                        </div>
+                                        <div className="text-xs text-gray-600 dark:text-gray-400 mt-1 flex justify-between">
+                                                <span>{syncStatus.isActive ? 'Syncing...' : 'Ready'}</span>
+                                                <span>{Math.round(progressPercentage)}%</span>
+                                        </div>
+                                        {syncStatus.lastSyncTime && (
+                                                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                                                        Last synced: {formatLastSync(syncStatus.lastSyncTime)}
+                                                </p>
+                                        )}
+                                        {syncStatus.libraryName && (
+                                                <p className="text-xs text-blue-700 dark:text-blue-300 mt-1 font-medium">
+                                                        {syncStatus.libraryName}
+                                                </p>
+                                        )}
+                                </div>
+                        </div>
+                </div>
+        );
 }
 
 renderWidget(SyncStatusWidget);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ const SANDBOX_SUFFIX = '-sandbox';
 
 const config = {
 	mode: isProd ? 'production' : 'development',
-	entry: glob.sync('./src/**/*.ts').reduce(function (obj, el) {
+	entry: glob.sync('./src/**/*.{ts,tsx}').reduce(function (obj, el) {
 		obj[path.parse(el).name] = el;
 		obj[path.parse(el).name + SANDBOX_SUFFIX] = el;
 		return obj;


### PR DESCRIPTION
## Summary
- add `ZOTERO_CONNECTOR_HOME` power-up
- register connector home power-up and update widget filter
- drop progress/syncing properties from library power-up
- remove power-up property logic from widget
- store sync progress and status in session storage
- integrate abort checks into `ZoteroSyncManager`
- fix duplicate `setLibraryKey` implementation
- handle undefined case in `checkForceStopFlag`
- redesign sync status widget with a round button and bar

## Testing
- `npm run check-types`

------
https://chatgpt.com/codex/tasks/task_e_686abe16761c8324813c1b2d3ab38c07