### PR TITLE
Support markdown parsing for Zotero item titles

### DIFF
--- a/src/sync/propertyHydrator.ts
+++ b/src/sync/propertyHydrator.ts
@@ -139,10 +139,13 @@ export class ZoteroPropertyHydrator {
 						continue;
 					}
 
-					if (isTitleLikeField(matchingKey)) {
-						await rem.setText([propertyValue]);
-						continue;
-					}
+                                        if (isTitleLikeField(matchingKey)) {
+                                                const safeTitle = await this.plugin.richText.parseFromMarkdown(
+                                                        String(propertyValue)
+                                                );
+                                                await rem.setText(safeTitle);
+                                                continue;
+                                        }
 
 					if (propertyType === PropertyType.URL) {
 						const linkID = await this.plugin.rem.createLinkRem(propertyValue, true);

--- a/src/sync/treeBuilder.ts
+++ b/src/sync/treeBuilder.ts
@@ -261,9 +261,12 @@ export class TreeBuilder {
 	private async updateItems(items: Item[]): Promise<void> {
 		for (const item of items) {
 			const remNode = this.nodeCache.get(item.key);
-			if (remNode) {
-				await remNode.rem.setText([item.data.title ?? '']);
-				item.rem = remNode.rem;
+                        if (remNode) {
+                                const safeTitle = await this.plugin.richText.parseFromMarkdown(
+                                        item.data.title ?? ''
+                                );
+                                await remNode.rem.setText(safeTitle);
+                                item.rem = remNode.rem;
 				const newParentId = item.data.parentItem || item.data.collections?.[0] || null;
 				if (remNode.zoteroParentId !== newParentId) {
 					remNode.zoteroParentId = newParentId;


### PR DESCRIPTION
## Summary
- safely parse Zotero item titles using `plugin.richText.parseFromMarkdown`
- update item text handling to support LaTeX titles

## Testing
- `npm run check-types`

------
https://chatgpt.com/codex/tasks/task_e_686ad10a8a5c8324baacc4afada91c89