### PR TITLE
Add multi-library sync progress tracking

### DIFF
--- a/.hintrc
+++ b/.hintrc
@@ -1,0 +1,15 @@
+{
+  "extends": [
+    "development"
+  ],
+  "hints": {
+    "compat-api/css": [
+      "default",
+      {
+        "ignore": [
+          "user-select"
+        ]
+      }
+    ]
+  }
+}

--- a/src/api/zotero.ts
+++ b/src/api/zotero.ts
@@ -3,12 +3,12 @@ import type { RNPlugin } from '@remnote/plugin-sdk';
 // @ts-ignore
 import createZoteroClient from 'zotero-api-client';
 import type {
-        Collection,
-        Item,
-        ZoteroCollectionResponse,
-        ZoteroItemResponse,
+	Collection,
+	Item,
+	ZoteroCollectionResponse,
+	ZoteroItemResponse,
 } from '../types/types';
-import { logMessage, LogType } from '../utils/logging';
+import { LogType, logMessage } from '../utils/logging';
 import { fromZoteroCollection, fromZoteroItem } from '../utils/zoteroConverters';
 
 /**
@@ -137,17 +137,17 @@ export class ZoteroAPI {
 		libraryType?: 'user' | 'group',
 		libraryId?: string
 	): Promise<{ items: Item[]; collections: Collection[] }> {
-                const [items, collections] = await Promise.all([
-                        this.fetchItems(libraryType, libraryId),
-                        this.fetchCollections(libraryType, libraryId),
-                ]);
-                await logMessage(
-                        this.plugin,
-                        `Fetched ${items.length} items and ${collections.length} collections from Zotero.`,
-                        LogType.Debug,
-                        false
-                );
-                return { items, collections };
+		const [items, collections] = await Promise.all([
+			this.fetchItems(libraryType, libraryId),
+			this.fetchCollections(libraryType, libraryId),
+		]);
+		await logMessage(
+			this.plugin,
+			`Fetched ${items.length} items and ${collections.length} collections from Zotero.`,
+			LogType.Debug,
+			false
+		);
+		return { items, collections };
 	}
 }
 
@@ -185,18 +185,18 @@ export async function fetchLibraries(plugin: RNPlugin): Promise<ZoteroLibraryInf
 			type: 'group' as const,
 		}));
 		return [{ id: String(userId), name: userName, type: 'user' as const }, ...groups];
-        } catch (err) {
-                await logMessage(
-                        plugin,
-                        'Failed to fetch group libraries',
-                        LogType.Error,
-                        false,
-                        String(err)
-                );
+	} catch (err) {
+		await logMessage(
+			plugin,
+			'Failed to fetch group libraries',
+			LogType.Error,
+			false,
+			String(err)
+		);
 
-                await plugin.app.toast(
-                        'Failed to fetch group libraries. Your browser may be blocking the request.'
-                );
-                return [{ id: String(userId), name: 'My Library', type: 'user' }];
-        }
+		await plugin.app.toast(
+			'Failed to fetch group libraries. Your browser may be blocking the request.'
+		);
+		return [{ id: String(userId), name: 'My Library', type: 'user' }];
+	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -518,7 +518,7 @@ async function registerDebugCommands(plugin: RNPlugin) {
 
 async function registerWidgets(plugin: RNPlugin) {
 	await plugin.app.registerWidget('syncStatusWidget', WidgetLocation.DocumentBelowTitle, {
-		dimensions: { height: 300, width: 500 },
+		dimensions: { height: 180, width: 420 },
 		powerupFilter: powerupCodes.ZOTERO_CONNECTOR_HOME,
 	});
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { itemTypes } from './constants/zoteroItemSchema';
 import { autoSync } from './services/autoSync';
 import { ensureZoteroLibraryRemExists } from './services/ensureUIPrettyZoteroRemExist';
 import { registerIconCSS } from './services/iconCSS';
-import { markAbortRequested, createRem } from './services/pluginIO';
+import { createRem, markAbortRequested } from './services/pluginIO';
 import { registerItemPowerups } from './services/zoteroSchemaToRemNote';
 import { ZoteroSyncManager } from './sync/zoteroSyncManager';
 import { LogType, logMessage } from './utils/logging';
@@ -518,7 +518,7 @@ async function registerDebugCommands(plugin: RNPlugin) {
 
 async function registerWidgets(plugin: RNPlugin) {
 	await plugin.app.registerWidget('syncStatusWidget', WidgetLocation.DocumentBelowTitle, {
-		dimensions: { height: 300, width: 300 },
+		dimensions: { height: 300, width: 500 },
 		powerupFilter: powerupCodes.ZOTERO_CONNECTOR_HOME,
 	});
 }

--- a/src/services/ensureUIPrettyZoteroRemExist.ts
+++ b/src/services/ensureUIPrettyZoteroRemExist.ts
@@ -165,10 +165,10 @@ export async function getZoteroLibraryRem(
 	const zoteroLibraryPowerUpRem = await plugin.powerup.getPowerupByCode(
 		powerupCodes.ZOTERO_CONNECTOR_HOME
 	);
-        if (!zoteroLibraryPowerUpRem) {
-                await logMessage(plugin, 'Zotero Library Power-Up not found!', LogType.Error, false);
-                return null;
-        }
+	if (!zoteroLibraryPowerUpRem) {
+		await logMessage(plugin, 'Zotero Library Power-Up not found!', LogType.Error, false);
+		return null;
+	}
 	const zoteroLibraryRem = (await zoteroLibraryPowerUpRem.taggedRem())[0];
 	return zoteroLibraryRem || null;
 }
@@ -191,10 +191,10 @@ export async function getUnfiledItemsRem(
 	const unfiledZoteroItemsPowerup = await plugin.powerup.getPowerupByCode(
 		powerupCodes.ZOTERO_UNFILED_ITEMS
 	);
-        if (!unfiledZoteroItemsPowerup) {
-                await logMessage(plugin, 'Unfiled Power-Up not found!', LogType.Error, false);
-                return null;
-        }
+	if (!unfiledZoteroItemsPowerup) {
+		await logMessage(plugin, 'Unfiled Power-Up not found!', LogType.Error, false);
+		return null;
+	}
 	const firstUnfiledZoteroItem = (await unfiledZoteroItemsPowerup.taggedRem())[0];
 	return firstUnfiledZoteroItem || null;
 }

--- a/src/services/iconCSS.ts
+++ b/src/services/iconCSS.ts
@@ -1,5 +1,5 @@
 import type { RNPlugin } from '@remnote/plugin-sdk';
-import { logMessage, LogType } from '../utils/logging';
+import { LogType, logMessage } from '../utils/logging';
 
 /**
  * Maps RemNote tag identifiers → icon basenames (no theme suffix).
@@ -131,12 +131,12 @@ function buildCSS(): string {
 /* RemNote plugin entry                                                    */
 /*───────────────────────────────────────────────────────────────────────────*/
 export async function registerIconCSS(plugin: RNPlugin): Promise<void> {
-        const css = buildCSS();
-        await logMessage(
-                plugin,
-                `[Citationista‑Icons] injecting ${css.length} chars`,
-                LogType.Debug,
-                false
-        );
-        await plugin.app.registerCSS('citationista-icons', css);
+	const css = buildCSS();
+	await logMessage(
+		plugin,
+		`[Citationista‑Icons] injecting ${css.length} chars`,
+		LogType.Debug,
+		false
+	);
+	await plugin.app.registerCSS('citationista-icons', css);
 }

--- a/src/sync/mergeUpdatedItems.ts
+++ b/src/sync/mergeUpdatedItems.ts
@@ -2,8 +2,8 @@
 import type { RNPlugin } from '@remnote/plugin-sdk';
 import { powerupCodes } from '../constants/constants';
 import type { ChangeSet, Item, RemNode, ZoteroItemData } from '../types/types';
+import { LogType, logMessage } from '../utils/logging';
 import { threeWayMerge } from './threeWayMerge';
-import { logMessage, LogType } from '../utils/logging';
 
 /**
  * For each updated item in the ChangeSet, merge the local data, remote data, and the previous shadow copy.
@@ -31,18 +31,18 @@ export async function mergeUpdatedItems(
 				'fullData'
 			);
 			if (localDataStr?.[0]) {
-                                try {
-                                        localData = JSON.parse(localDataStr[0]);
-                                } catch (e) {
-                                        await logMessage(
-                                                _plugin,
-                                                `Failed to parse local data for item ${updatedItem.key}`,
-                                                LogType.Warning,
-                                                false,
-                                                String(e)
-                                        );
-                                        localData = {};
-                                }
+				try {
+					localData = JSON.parse(localDataStr[0]);
+				} catch (e) {
+					await logMessage(
+						_plugin,
+						`Failed to parse local data for item ${updatedItem.key}`,
+						LogType.Warning,
+						false,
+						String(e)
+					);
+					localData = {};
+				}
 			}
 			// attach rem to updatedItem for downstream steps
 			updatedItem.rem = remNode.rem;

--- a/src/sync/treeBuilder.ts
+++ b/src/sync/treeBuilder.ts
@@ -128,139 +128,129 @@ export class TreeBuilder {
 		);
 	}
 
-       async applyChanges(
-               changes: ChangeSet,
-               onProgress?: () => Promise<void>
-       ): Promise<void> {
-               await this.handleCollections(changes, onProgress);
-               await this.handleItems(changes, onProgress);
-       }
+	async applyChanges(changes: ChangeSet, onProgress?: () => Promise<void>): Promise<void> {
+		await this.handleCollections(changes, onProgress);
+		await this.handleItems(changes, onProgress);
+	}
 
-       private async handleCollections(
-               changes: ChangeSet,
-               onProgress?: () => Promise<void>
-       ): Promise<void> {
-               await this.createCollections(changes.newCollections, onProgress);
-               await this.updateCollections(changes.updatedCollections, onProgress);
-               await this.deleteCollections(changes.deletedCollections, onProgress);
-               await this.moveCollections([
-                       ...changes.newCollections,
-                       ...changes.movedCollections,
-                       ...changes.updatedCollections,
-               ], onProgress);
-       }
+	private async handleCollections(
+		changes: ChangeSet,
+		onProgress?: () => Promise<void>
+	): Promise<void> {
+		await this.createCollections(changes.newCollections, onProgress);
+		await this.updateCollections(changes.updatedCollections, onProgress);
+		await this.deleteCollections(changes.deletedCollections, onProgress);
+		await this.moveCollections(
+			[...changes.newCollections, ...changes.movedCollections, ...changes.updatedCollections],
+			onProgress
+		);
+	}
 
-       private async handleItems(
-               changes: ChangeSet,
-               onProgress?: () => Promise<void>
-       ): Promise<void> {
-               await this.createItems(changes.newItems, onProgress);
-               await this.updateItems(changes.updatedItems, onProgress);
-               await this.deleteItems(changes.deletedItems, onProgress);
-               await this.moveItems(
-                       [...changes.newItems, ...changes.movedItems, ...changes.updatedItems],
-                       onProgress
-               );
-       }
+	private async handleItems(changes: ChangeSet, onProgress?: () => Promise<void>): Promise<void> {
+		await this.createItems(changes.newItems, onProgress);
+		await this.updateItems(changes.updatedItems, onProgress);
+		await this.deleteItems(changes.deletedItems, onProgress);
+		await this.moveItems(
+			[...changes.newItems, ...changes.movedItems, ...changes.updatedItems],
+			onProgress
+		);
+	}
 
 	// Collection methods.
-       private async createCollections(
-               collections: Collection[],
-               onProgress?: () => Promise<void>
-       ): Promise<void> {
-               for (const collection of collections) {
-                       const rem = await createRem(this.plugin, this.libraryKey ?? undefined);
-                       if (!rem) continue;
-                       await rem.addPowerup(powerupCodes.COLLECTION);
-                       await rem.setPowerupProperty(powerupCodes.COLLECTION, 'key', [collection.key]);
-                       collection.rem = rem;
-                       this.nodeCache.set(collection.key, {
-                               remId: rem._id,
-                               zoteroId: collection.key,
-                               zoteroParentId: collection.parentCollection || null,
-                               rem,
-                       });
-                       if (onProgress) await onProgress();
-               }
-       }
+	private async createCollections(
+		collections: Collection[],
+		onProgress?: () => Promise<void>
+	): Promise<void> {
+		for (const collection of collections) {
+			const rem = await createRem(this.plugin, this.libraryKey ?? undefined);
+			if (!rem) continue;
+			await rem.addPowerup(powerupCodes.COLLECTION);
+			await rem.setPowerupProperty(powerupCodes.COLLECTION, 'key', [collection.key]);
+			collection.rem = rem;
+			this.nodeCache.set(collection.key, {
+				remId: rem._id,
+				zoteroId: collection.key,
+				zoteroParentId: collection.parentCollection || null,
+				rem,
+			});
+			if (onProgress) await onProgress();
+		}
+	}
 
-       private async updateCollections(
-               collections: Collection[],
-               onProgress?: () => Promise<void>
-       ): Promise<void> {
-               for (const collection of collections) {
-                       const remNode = this.nodeCache.get(collection.key);
-                       if (remNode) {
-                               await remNode.rem.setText([collection.name]);
-                               collection.rem = remNode.rem;
-                               const newParentId = collection.parentCollection || null;
-                               if (remNode.zoteroParentId !== newParentId) {
-                                       remNode.zoteroParentId = newParentId;
-                               }
-                       } else {
-                               logMessage(
-                                       this.plugin,
-                                       `Collection ${collection.key} not found, creating it`,
-                                       LogType.Info
-                               );
-                               await this.createCollections([collection]);
-                       }
-                       if (onProgress) await onProgress();
-               }
-       }
+	private async updateCollections(
+		collections: Collection[],
+		onProgress?: () => Promise<void>
+	): Promise<void> {
+		for (const collection of collections) {
+			const remNode = this.nodeCache.get(collection.key);
+			if (remNode) {
+				await remNode.rem.setText([collection.name]);
+				collection.rem = remNode.rem;
+				const newParentId = collection.parentCollection || null;
+				if (remNode.zoteroParentId !== newParentId) {
+					remNode.zoteroParentId = newParentId;
+				}
+			} else {
+				logMessage(
+					this.plugin,
+					`Collection ${collection.key} not found, creating it`,
+					LogType.Info
+				);
+				await this.createCollections([collection]);
+			}
+			if (onProgress) await onProgress();
+		}
+	}
 
-       private async deleteCollections(
-               collections: Collection[],
-               onProgress?: () => Promise<void>
-       ): Promise<void> {
-               const deletionPromises: Promise<void>[] = [];
-               for (const collection of collections) {
-                       const remNode = this.nodeCache.get(collection.key);
-                       if (remNode) {
-                               deletionPromises.push(remNode.rem.remove());
-                               this.nodeCache.delete(collection.key);
-                               if (onProgress) await onProgress();
-                       }
-               }
-               await Promise.all(deletionPromises);
-       }
+	private async deleteCollections(
+		collections: Collection[],
+		onProgress?: () => Promise<void>
+	): Promise<void> {
+		const deletionPromises: Promise<void>[] = [];
+		for (const collection of collections) {
+			const remNode = this.nodeCache.get(collection.key);
+			if (remNode) {
+				deletionPromises.push(remNode.rem.remove());
+				this.nodeCache.delete(collection.key);
+				if (onProgress) await onProgress();
+			}
+		}
+		await Promise.all(deletionPromises);
+	}
 
-       private async moveCollections(
-               collections: Collection[],
-               onProgress?: () => Promise<void>
-       ): Promise<void> {
-               for (const collection of collections) {
-                       const remNode = this.nodeCache.get(collection.key);
-                       if (remNode) {
-                               const newParentId = collection.parentCollection || null;
-                               const parentNode = newParentId ? this.nodeCache.get(newParentId) : null;
-                               if (parentNode) {
-                                       await remNode.rem.setParent(parentNode.rem);
-                               } else {
-                                       // Fallback: assign to the Zotero Library Rem.
+	private async moveCollections(
+		collections: Collection[],
+		onProgress?: () => Promise<void>
+	): Promise<void> {
+		for (const collection of collections) {
+			const remNode = this.nodeCache.get(collection.key);
+			if (remNode) {
+				const newParentId = collection.parentCollection || null;
+				const parentNode = newParentId ? this.nodeCache.get(newParentId) : null;
+				if (parentNode) {
+					await remNode.rem.setParent(parentNode.rem);
+				} else {
+					// Fallback: assign to the Zotero Library Rem.
 
 					const zoteroLibraryRem = await getZoteroLibraryRem(
 						this.plugin,
 						this.libraryKey ?? undefined
 					);
 
-                                       if (zoteroLibraryRem) {
-                                               await remNode.rem.setParent(zoteroLibraryRem);
-                                       }
-                               }
-                               remNode.zoteroParentId = newParentId;
-                               if (onProgress) await onProgress();
-                       }
-               }
-       }
+					if (zoteroLibraryRem) {
+						await remNode.rem.setParent(zoteroLibraryRem);
+					}
+				}
+				remNode.zoteroParentId = newParentId;
+				if (onProgress) await onProgress();
+			}
+		}
+	}
 
 	// Item methods.
-       private async createItems(
-               items: Item[],
-               onProgress?: () => Promise<void>
-       ): Promise<void> {
-               for (const item of items) {
-                       if (await checkAbortFlag(this.plugin)) return;
+	private async createItems(items: Item[], onProgress?: () => Promise<void>): Promise<void> {
+		for (const item of items) {
+			if (await checkAbortFlag(this.plugin)) return;
 			const itemTypeCode = generatePowerupCode(item.data.itemType);
 			const itemTypePowerup = await this.plugin.powerup.getPowerupByCode(itemTypeCode);
 
@@ -293,22 +283,19 @@ export class TreeBuilder {
 				continue;
 			}
 			item.rem = rem;
-                       this.nodeCache.set(item.key, {
-                               remId: rem._id,
-                               zoteroId: item.key,
-                               zoteroParentId: item.data.parentItem || item.data.collections?.[0] || null,
-                               rem,
-                       });
-                       if (onProgress) await onProgress();
-               }
-       }
+			this.nodeCache.set(item.key, {
+				remId: rem._id,
+				zoteroId: item.key,
+				zoteroParentId: item.data.parentItem || item.data.collections?.[0] || null,
+				rem,
+			});
+			if (onProgress) await onProgress();
+		}
+	}
 
-       private async updateItems(
-               items: Item[],
-               onProgress?: () => Promise<void>
-       ): Promise<void> {
-               for (const item of items) {
-                       if (await checkAbortFlag(this.plugin)) return;
+	private async updateItems(items: Item[], onProgress?: () => Promise<void>): Promise<void> {
+		for (const item of items) {
+			if (await checkAbortFlag(this.plugin)) return;
 			const remNode = this.nodeCache.get(item.key);
 			if (remNode) {
 				const safeTitle = await this.plugin.richText.parseFromMarkdown(
@@ -326,37 +313,31 @@ export class TreeBuilder {
 					`Item ${item.key} not found, creating it`,
 					LogType.Info
 				);
-                               await this.createItems([item]);
-                       }
-                       if (onProgress) await onProgress();
-               }
-       }
+				await this.createItems([item]);
+			}
+			if (onProgress) await onProgress();
+		}
+	}
 
-       private async deleteItems(
-               items: Item[],
-               onProgress?: () => Promise<void>
-       ): Promise<void> {
-               const deletionPromises: Promise<void>[] = [];
-               for (const item of items) {
-                       if (await checkAbortFlag(this.plugin)) return;
-                       const remNode = this.nodeCache.get(item.key);
-                       if (remNode) {
-                               deletionPromises.push(remNode.rem.remove());
-                               this.nodeCache.delete(item.key);
-                               if (onProgress) await onProgress();
-                       }
-               }
-               await Promise.all(deletionPromises);
-       }
+	private async deleteItems(items: Item[], onProgress?: () => Promise<void>): Promise<void> {
+		const deletionPromises: Promise<void>[] = [];
+		for (const item of items) {
+			if (await checkAbortFlag(this.plugin)) return;
+			const remNode = this.nodeCache.get(item.key);
+			if (remNode) {
+				deletionPromises.push(remNode.rem.remove());
+				this.nodeCache.delete(item.key);
+				if (onProgress) await onProgress();
+			}
+		}
+		await Promise.all(deletionPromises);
+	}
 
-       private async moveItems(
-               items: Item[],
-               onProgress?: () => Promise<void>
-       ): Promise<void> {
-               const unfiledZoteroItemsRem = await getUnfiledItemsRem(
-                       this.plugin,
-                       this.libraryKey ?? undefined
-               );
+	private async moveItems(items: Item[], onProgress?: () => Promise<void>): Promise<void> {
+		const unfiledZoteroItemsRem = await getUnfiledItemsRem(
+			this.plugin,
+			this.libraryKey ?? undefined
+		);
 
 		const multipleCollectionsBehavior = (await this.plugin.settings.getSetting(
 			'multiple-colections-behavior'
@@ -438,15 +419,15 @@ export class TreeBuilder {
 							emptyRem?.setText([{ i: 'q', _id: remNode.rem._id }]); // a workaround behavior
 						}
 					}
-                                        remNode.zoteroParentId = primaryParent.zoteroId;
-                                }
-                        }
-                        if (remNode && onProgress) await onProgress();
-                }
-                await logMessage(
-                        this.plugin,
-                        `Unfiled Items: ${listOfUnfiledItems.length}`,
-                        LogType.Debug,
+					remNode.zoteroParentId = primaryParent.zoteroId;
+				}
+			}
+			if (remNode && onProgress) await onProgress();
+		}
+		await logMessage(
+			this.plugin,
+			`Unfiled Items: ${listOfUnfiledItems.length}`,
+			LogType.Debug,
 			false
 		);
 	}

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -42,24 +42,21 @@ type LogParams = Record<string, unknown> | unknown[] | string | number | boolean
  * @param params - Additional parameters to be logged.
  */
 export async function logMessage(
-        plugin: ReactRNPlugin | RNPlugin,
-        message: LogMessage,
-        type: LogType,
-        isToast: boolean = true,
-        params?: LogParams
+	plugin: ReactRNPlugin | RNPlugin,
+	message: LogMessage,
+	type: LogType,
+	isToast: boolean = true,
+	params?: LogParams
 ) {
-        const debugMode = await plugin.settings.getSetting('debug-mode');
-        const emergent =
-                type === LogType.Error ||
-                type === LogType.Fatal ||
-                type === LogType.Critical;
+	const debugMode = await plugin.settings.getSetting('debug-mode');
+	const emergent = type === LogType.Error || type === LogType.Fatal || type === LogType.Critical;
 
-        if (debugMode || emergent) {
-                const baseplateIdentifier = `${logTypeToEmoji[type].emoji}+📚`;
-                const consoleEmitType = type.toLowerCase() as 'warn' | 'info' | 'error' | 'log';
-                switch (consoleEmitType) {
-                        case 'warn':
-                                console.warn(baseplateIdentifier, message, params);
+	if (debugMode || emergent) {
+		const baseplateIdentifier = `${logTypeToEmoji[type].emoji}+📚`;
+		const consoleEmitType = type.toLowerCase() as 'warn' | 'info' | 'error' | 'log';
+		switch (consoleEmitType) {
+			case 'warn':
+				console.warn(baseplateIdentifier, message, params);
 				break;
 			case 'info':
 				console.info(baseplateIdentifier, message, params);
@@ -76,15 +73,15 @@ export async function logMessage(
 				console.log(baseplateIdentifier, message, params);
 				break;
 		}
-        }
-        if (isToast && (debugMode || emergent)) {
-                // Convert message to string for toast display
-                const toastMessage =
-                        message instanceof Error
-                                ? message.message
-                                : Array.isArray(message)
+	}
+	if (isToast && (debugMode || emergent)) {
+		// Convert message to string for toast display
+		const toastMessage =
+			message instanceof Error
+				? message.message
+				: Array.isArray(message)
 					? message.join(' ')
 					: String(message);
-                await plugin.app.toast(`${logTypeToEmoji[type].emoji} ${toastMessage}`);
-        }
+		await plugin.app.toast(`${logTypeToEmoji[type].emoji} ${toastMessage}`);
+	}
 }

--- a/src/widgets/syncStatusWidget.css
+++ b/src/widgets/syncStatusWidget.css
@@ -1,29 +1,41 @@
 /* syncStatusWidget.css */
 
+/* 1) The root fills exactly the host dimensions, no extra scrollbars */
 #sync-status-root {
 	position: relative;
-	width: 100vw;
-	height: 100px;
-	max-width: 100vw;
+	width: 100%;
+	height: 100%;
 	box-sizing: border-box;
+	overflow: hidden;
 }
 
+/* 2) Card is fixed-size (420×180), row layout, with internal overflow hidden */
 .sync-status-card {
 	background-color: #232136;
-	border-color: #393552;
+	border: 2px solid #393552;
 	color: #eceff4;
-	margin-bottom: 0;
-	min-width: 340px;
-	max-width: 420px;
+
 	width: 100%;
-	min-height: 110px;
+	height: 100%;
+	max-width: 420px;
+	max-height: 180px;
+
 	display: flex;
+	flex-direction: row;
 	align-items: center;
+
 	box-sizing: border-box;
-	padding-left: 2rem;
-	padding-right: 2rem;
+	padding: 1rem 1.75rem;
+	gap: 1.5rem;
+
+	border-radius: 1rem;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+
+	overflow: hidden;
+	margin-bottom: 0;
 }
 
+/* 3) Buttons column */
 .sync-status-card .sync-status-btn-col {
 	display: flex;
 	flex-direction: column;
@@ -31,20 +43,19 @@
 	justify-content: center;
 	flex: 0 0 auto;
 	min-width: 140px;
-	margin-right: 2rem;
 	gap: 1.1rem;
 }
 
+/* 4) Button styles */
 .sync-action-btn,
 .abort-action-btn {
-	width: auto;
 	min-width: 80px;
 	padding: 0.4rem 1.1rem;
 	border: none;
 	border-radius: 0.5rem;
 	font-size: 1rem;
 	font-weight: 500;
-	box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 	transition:
 		background 0.18s,
 		color 0.18s,
@@ -61,25 +72,22 @@
 	background: linear-gradient(90deg, #c4a7e7 0%, #a78bfa 100%);
 	color: #232136;
 	border: 2px solid #c4a7e7;
-	box-shadow: 0 4px 16px 0 rgba(196, 167, 231, 0.1);
 }
 .sync-action-btn:hover:not(.disabled) {
 	background: linear-gradient(90deg, #a78bfa 0%, #c4a7e7 100%);
-	color: #232136;
 	opacity: 0.96;
-	box-shadow: 0 6px 20px 0 rgba(196, 167, 231, 0.18);
+	box-shadow: 0 6px 20px rgba(196, 167, 231, 0.18);
 }
 
 .abort-action-btn {
 	background: #393552;
 	color: #c4a7e7;
 	border: 2px solid #c4a7e7;
-	box-shadow: 0 2px 8px 0 rgba(60, 40, 100, 0.1);
 }
 .abort-action-btn:hover:not(.disabled) {
 	background: #c4a7e7;
 	color: #232136;
-	box-shadow: 0 4px 16px 0 rgba(196, 167, 231, 0.18);
+	box-shadow: 0 4px 16px rgba(196, 167, 231, 0.18);
 }
 
 .sync-action-btn.disabled,
@@ -94,6 +102,7 @@
 	box-shadow: none;
 }
 
+/* 5) Dividers & progress bar */
 .sync-status-divider {
 	border-color: #393552;
 	margin: 6px 0;
@@ -113,20 +122,31 @@
 	min-width: 2px;
 }
 
+/* 6) Text styles */
 .sync-status-info {
 	color: #a6adc8;
+	font-size: 0.75rem;
 }
 
 .sync-status-library {
 	color: #c4a7e7;
+	font-size: 0.75rem;
 }
 
+/* 7) Library list: only this scrolls internally */
 .sync-status-library-list {
 	display: flex;
 	flex-direction: column;
 	gap: 4px;
+
+	max-height: 4.5rem; /* adjust as needed */
+	overflow-y: auto;
+}
+.sync-status-library-list::-webkit-scrollbar {
+	display: none;
 }
 
+/* 8) Each library entry */
 .sync-status-library-item {
 	display: flex;
 	justify-content: space-between;
@@ -136,11 +156,12 @@
 	font-size: 0.65rem;
 }
 
+/* 9) Info column (right side) */
 .sync-status-card .flex-1 {
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
 	height: 100%;
-	padding-left: 0.25rem;
-	padding-right: 1.25rem;
+	padding: 0 1.25rem 0 0.25rem;
+	overflow: visible; /* let list handle its own scrolling */
 }

--- a/src/widgets/syncStatusWidget.css
+++ b/src/widgets/syncStatusWidget.css
@@ -45,8 +45,10 @@
 }
 
 .sync-status-library-item {
-        display: flex;
-        justify-content: space-between;
-        color: #c4a7e7;
-        font-size: 0.75rem;
+       display: flex;
+       justify-content: space-between;
+       align-items: center;
+       gap: 0.5rem;
+       color: #c4a7e7;
+       font-size: 0.65rem;
 }

--- a/src/widgets/syncStatusWidget.css
+++ b/src/widgets/syncStatusWidget.css
@@ -36,5 +36,17 @@
 }
 
 .sync-status-library {
-	color: #c4a7e7;
+        color: #c4a7e7;
+}
+
+.sync-status-library-list {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+}
+
+.sync-status-library-item {
+        display: flex;
+        justify-content: space-between;
+        color: #c4a7e7;
 }

--- a/src/widgets/syncStatusWidget.css
+++ b/src/widgets/syncStatusWidget.css
@@ -2,8 +2,10 @@
 
 #sync-status-root {
 	position: relative;
-	width: 100%;
-	height: 100%;
+	width: 100vw;
+	height: 100px;
+	max-width: 100vw;
+	box-sizing: border-box;
 }
 
 .sync-status-card {
@@ -11,6 +13,85 @@
 	border-color: #393552;
 	color: #eceff4;
 	margin-bottom: 0;
+	min-width: 340px;
+	max-width: 420px;
+	width: 100%;
+	min-height: 110px;
+	display: flex;
+	align-items: center;
+	box-sizing: border-box;
+	padding-left: 2rem;
+	padding-right: 2rem;
+}
+
+.sync-status-card .sync-status-btn-col {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 auto;
+	min-width: 140px;
+	margin-right: 2rem;
+	gap: 1.1rem;
+}
+
+.sync-action-btn,
+.abort-action-btn {
+	width: auto;
+	min-width: 80px;
+	padding: 0.4rem 1.1rem;
+	border: none;
+	border-radius: 0.5rem;
+	font-size: 1rem;
+	font-weight: 500;
+	box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
+	transition:
+		background 0.18s,
+		color 0.18s,
+		opacity 0.18s,
+		box-shadow 0.18s;
+	cursor: pointer;
+	outline: none;
+	letter-spacing: 0.01em;
+	text-align: center;
+	display: block;
+}
+
+.sync-action-btn {
+	background: linear-gradient(90deg, #c4a7e7 0%, #a78bfa 100%);
+	color: #232136;
+	border: 2px solid #c4a7e7;
+	box-shadow: 0 4px 16px 0 rgba(196, 167, 231, 0.1);
+}
+.sync-action-btn:hover:not(.disabled) {
+	background: linear-gradient(90deg, #a78bfa 0%, #c4a7e7 100%);
+	color: #232136;
+	opacity: 0.96;
+	box-shadow: 0 6px 20px 0 rgba(196, 167, 231, 0.18);
+}
+
+.abort-action-btn {
+	background: #393552;
+	color: #c4a7e7;
+	border: 2px solid #c4a7e7;
+	box-shadow: 0 2px 8px 0 rgba(60, 40, 100, 0.1);
+}
+.abort-action-btn:hover:not(.disabled) {
+	background: #c4a7e7;
+	color: #232136;
+	box-shadow: 0 4px 16px 0 rgba(196, 167, 231, 0.18);
+}
+
+.sync-action-btn.disabled,
+.abort-action-btn.disabled,
+.sync-action-btn:disabled,
+.abort-action-btn:disabled {
+	background: #393552 !important;
+	color: #a6adc8 !important;
+	border-color: #393552 !important;
+	cursor: not-allowed;
+	opacity: 0.6;
+	box-shadow: none;
 }
 
 .sync-status-divider {
@@ -20,14 +101,16 @@
 
 .sync-status-progress-bg {
 	background-color: #393552;
+	border-radius: 9999px;
+	height: 0.5rem;
 }
 
 .sync-status-progress-bar {
-        height: 0.5rem;
-        border-radius: 9999px;
-        transition: all 0.2s;
-        background-color: var(--accent-color);
-        width: 0;
+	height: 0.5rem;
+	border-radius: 9999px;
+	transition: width 0.2s ease-in-out;
+	background: linear-gradient(90deg, #c4a7e7 0%, #a78bfa 100%);
+	min-width: 2px;
 }
 
 .sync-status-info {
@@ -35,20 +118,29 @@
 }
 
 .sync-status-library {
-        color: #c4a7e7;
+	color: #c4a7e7;
 }
 
 .sync-status-library-list {
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
 }
 
 .sync-status-library-item {
-       display: flex;
-       justify-content: space-between;
-       align-items: center;
-       gap: 0.5rem;
-       color: #c4a7e7;
-       font-size: 0.65rem;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 0.5rem;
+	color: #c4a7e7;
+	font-size: 0.65rem;
+}
+
+.sync-status-card .flex-1 {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	height: 100%;
+	padding-left: 0.25rem;
+	padding-right: 1.25rem;
 }

--- a/src/widgets/syncStatusWidget.css
+++ b/src/widgets/syncStatusWidget.css
@@ -23,12 +23,11 @@
 }
 
 .sync-status-progress-bar {
-	height: 0.5rem;
-	border-radius: 9999px;
-	transition: all 0.2s;
-	background-color: var(--accent-color);
-	/* Add width as a CSS variable for dynamic updates */
-	width: var(--progress-width, 0%);
+        height: 0.5rem;
+        border-radius: 9999px;
+        transition: all 0.2s;
+        background-color: var(--accent-color);
+        width: 0;
 }
 
 .sync-status-info {
@@ -49,4 +48,5 @@
         display: flex;
         justify-content: space-between;
         color: #c4a7e7;
+        font-size: 0.75rem;
 }

--- a/src/widgets/syncStatusWidget.tsx
+++ b/src/widgets/syncStatusWidget.tsx
@@ -6,41 +6,55 @@ import { ZoteroSyncManager } from '../sync/zoteroSyncManager';
 import { LogType, logMessage } from '../utils/logging';
 
 interface LibraryEntry {
-        name: string;
-        progress: number;
+	name: string;
+	progress: number;
 }
 
 interface SyncStatus {
-        isActive: boolean;
-        progress: number;
-        lastSyncTime?: Date;
-        libraryName?: string;
-        libraries?: LibraryEntry[];
-        timeRemaining?: number;
+	isActive: boolean;
+	progress: number;
+	lastSyncTime?: Date;
+	libraryName?: string;
+	libraries?: LibraryEntry[];
+	timeRemaining?: number;
 }
 
 function SyncStatusWidget() {
 	const plugin = usePlugin();
-        const [syncStatus, setSyncStatus] = useState<SyncStatus>({
-                isActive: false,
-                progress: 0,
-                timeRemaining: undefined,
-                libraries: [],
-        });
+	const [syncStatus, setSyncStatus] = useState<SyncStatus>({
+		isActive: false,
+		progress: 0,
+		timeRemaining: undefined,
+		libraries: [],
+	});
 	const [isProcessing, setIsProcessing] = useState(false);
 
 	// 1) INJECT A GLOBAL CSS RESET
 	useEffect(() => {
 		const style = document.createElement('style');
 		style.innerHTML = `
-			html, body {
-				margin: 0 !important;
-				padding: 0 !important;
-				width: 100% !important;
-				height: 100% !important;
-				overflow: hidden !important;
-			}
-		`;
+	  /* keep your html/body reset… */
+	  html, body {
+		margin: 0 !important;
+		padding: 0 !important;
+		width: 100% !important;
+		height: 100% !important;
+		overflow: hidden !important;
+	  }
+
+	  /* ↓ our “last in” overrides for the card itself ↓ */
+	  #sync-status-root {
+		height: auto !important;
+	  }
+	  .sync-status-card {
+		display: flex    !important;
+		width: min(90vw, 420px) !important;
+		padding: 1rem 1.75rem !important;
+		gap: 1.5rem      !important;
+		/* temporary debug outline—remove once you see it */
+		outline: 2px dashed lime !important;
+	  }
+	`;
 		document.head.appendChild(style);
 		return () => {
 			document.head.removeChild(style);
@@ -48,7 +62,7 @@ function SyncStatusWidget() {
 	}, []);
 
 	// Get current Zotero library Rem
-        const getCurrentLibraryRem = useCallback(async (): Promise<Rem | null> => {
+	const getCurrentLibraryRem = useCallback(async (): Promise<Rem | null> => {
 		const syncedLibraryId = await plugin.storage.getSynced('syncedLibraryId');
 		if (!syncedLibraryId) return null;
 
@@ -62,95 +76,110 @@ function SyncStatusWidget() {
 			return rem || null;
 		}
 
-                return null;
-        }, [plugin]);
+		return null;
+	}, [plugin]);
 
-        // Retrieve a library name by its key using the stored Rem mapping
-        const getLibraryName = useCallback(
-                async (key: string): Promise<string> => {
-                        const libraryRemMap = (await plugin.storage.getSynced('libraryRemMap')) as
-                                | Record<string, string>
-                                | undefined;
-                        const remId = libraryRemMap?.[key];
-                        if (remId) {
-                                const rem = await plugin.rem.findOne(remId);
-                                const text = await rem?.text;
-                                if (text) {
-                                        return (Array.isArray(text) ? text.join('') : String(text)) || key;
-                                }
-                        }
-                        return key;
-                },
-                [plugin]
-        );
+	// Retrieve a library name by its key using the stored Rem mapping
+	const getLibraryName = useCallback(
+		async (key: string): Promise<string> => {
+			const libraryRemMap = (await plugin.storage.getSynced('libraryRemMap')) as
+				| Record<string, string>
+				| undefined;
+			const remId = libraryRemMap?.[key];
+			if (remId) {
+				const rem = await plugin.rem.findOne(remId);
+				const text = await rem?.text;
+				if (text) {
+					return (Array.isArray(text) ? text.join('') : String(text)) || key;
+				}
+			}
+			return key;
+		},
+		[plugin]
+	);
 
 	// Update sync status from storage
-        const updateSyncStatus = useCallback(async () => {
-                try {
-                        const multi = await plugin.settings.getSetting('sync-multiple-libraries');
+	const updateSyncStatus = useCallback(async () => {
+		try {
+			const multi = await plugin.settings.getSetting('sync-multiple-libraries');
 
-                        const progress = ((await plugin.storage.getSession('syncProgress')) as number) || 0;
-                        const isActive = ((await plugin.storage.getSession('syncing')) as boolean) || false;
-                        const startTime = (await plugin.storage.getSession('syncStartTime')) as string | undefined;
-                        let timeRemaining: number | undefined = undefined;
-                        if (startTime && progress > 0.01 && progress < 1) {
-                                const start = new Date(startTime).getTime();
-                                const elapsed = Date.now() - start;
-                                const total = elapsed / progress;
-                                timeRemaining = Math.max(total - elapsed, 0);
-                        }
+			const progress = ((await plugin.storage.getSession('syncProgress')) as number) || 0;
+			const isActive = ((await plugin.storage.getSession('syncing')) as boolean) || false;
+			const startTime = (await plugin.storage.getSession('syncStartTime')) as
+				| string
+				| undefined;
+			let timeRemaining: number | undefined = undefined;
+			if (startTime && progress > 0.01 && progress < 1) {
+				const start = new Date(startTime).getTime();
+				const elapsed = Date.now() - start;
+				const total = elapsed / progress;
+				timeRemaining = Math.max(total - elapsed, 0);
+			}
 
-                        // When syncing multiple libraries, collect progress for each
-                        if (multi) {
-                                const progressMap = (await plugin.storage.getSession('multiLibraryProgress')) as
-                                        | Record<string, { progress: number; name: string }>
-                                        | undefined;
-                                const libraries: LibraryEntry[] = [];
-                                if (progressMap) {
-                                        for (const [key, val] of Object.entries(progressMap)) {
-                                                const name = val.name || (await getLibraryName(key));
-                                                libraries.push({ name, progress: val.progress });
-                                        }
-                                }
+			// When syncing multiple libraries, collect progress for each
+			if (multi) {
+				const progressMap = (await plugin.storage.getSession('multiLibraryProgress')) as
+					| Record<string, { progress: number; name: string }>
+					| undefined;
+				const libraries: LibraryEntry[] = [];
+				if (progressMap) {
+					for (const [key, val] of Object.entries(progressMap)) {
+						const name = val.name || (await getLibraryName(key));
+						libraries.push({ name, progress: val.progress });
+					}
+				}
 
-                                const lastSyncString = await plugin.storage.getSynced('lastSyncTime');
-                                const lastSyncTime = lastSyncString ? new Date(lastSyncString as string) : undefined;
+				const lastSyncString = await plugin.storage.getSynced('lastSyncTime');
+				const lastSyncTime = lastSyncString
+					? new Date(lastSyncString as string)
+					: undefined;
 
-                                setSyncStatus({
-                                        isActive,
-                                        progress,
-                                        lastSyncTime,
-                                        libraries,
-                                        timeRemaining,
-                                });
-                                return;
-                        }
+				setSyncStatus({
+					isActive,
+					progress,
+					lastSyncTime,
+					libraries,
+					timeRemaining,
+				});
+				return;
+			}
 
-                        // Single library mode
-                        const libraryRem = await getCurrentLibraryRem();
-                        if (!libraryRem) {
-                                setSyncStatus({ isActive: false, progress: 0, timeRemaining: undefined, libraries: [] });
-                                return;
-                        }
+			// Single library mode
+			const libraryRem = await getCurrentLibraryRem();
+			if (!libraryRem) {
+				setSyncStatus({
+					isActive: false,
+					progress: 0,
+					timeRemaining: undefined,
+					libraries: [],
+				});
+				return;
+			}
 
-                        const libraryText = libraryRem.text;
-                        const libraryName = (libraryText?.[0] as string) || 'Zotero Library';
+			const libraryText = libraryRem.text;
+			const libraryName = (libraryText?.[0] as string) || 'Zotero Library';
 
-                        const lastSyncString = await plugin.storage.getSynced('lastSyncTime');
-                        const lastSyncTime = lastSyncString ? new Date(lastSyncString as string) : undefined;
+			const lastSyncString = await plugin.storage.getSynced('lastSyncTime');
+			const lastSyncTime = lastSyncString ? new Date(lastSyncString as string) : undefined;
 
-                        setSyncStatus({
-                                isActive,
-                                progress,
-                                lastSyncTime,
-                                libraryName,
-                                libraries: undefined,
-                                timeRemaining,
-                        });
-                } catch (error) {
-                        await logMessage(plugin, 'Error updating sync status', LogType.Error, false, String(error));
-                }
-        }, [getCurrentLibraryRem, plugin, getLibraryName]);
+			setSyncStatus({
+				isActive,
+				progress,
+				lastSyncTime,
+				libraryName,
+				libraries: undefined,
+				timeRemaining,
+			});
+		} catch (error) {
+			await logMessage(
+				plugin,
+				'Error updating sync status',
+				LogType.Error,
+				false,
+				String(error)
+			);
+		}
+	}, [getCurrentLibraryRem, plugin, getLibraryName]);
 
 	// Handle sync now button
 	const handleSyncNow = async () => {
@@ -213,30 +242,54 @@ function SyncStatusWidget() {
 
 	const progressPercentage = Math.min(100, Math.max(0, syncStatus.progress * 100));
 
+	// Debug logging for progress
+	useEffect(() => {
+		console.log('Sync Status:', {
+			isActive: syncStatus.isActive,
+			progress: syncStatus.progress,
+			progressPercentage,
+			rawProgress: syncStatus.progress,
+		});
+	}, [syncStatus.progress, syncStatus.isActive, progressPercentage]);
+
+	// Test mode - uncomment to test progress bar visually
+	// const testProgressPercentage = 45; // Test with 45% progress
+
 	// 2) USE A FULL‐BLEED WRAPPER AND BOTTOM-0
 	return (
 		<div id="sync-status-root">
 			<div className="fixed inset-x-0 bottom-0 z-50 pointer-events-none flex justify-center">
 				<div className="pointer-events-auto rounded-xl shadow-md p-4 flex items-center gap-4 border sync-status-card">
-					<button
-						type="button"
-						onClick={syncStatus.isActive ? handleAbortSync : handleSyncNow}
-						disabled={isProcessing}
-						className={`w-12 h-12 rounded-full text-white flex items-center justify-center transition-colors ${
-							syncStatus.isActive
-								? 'bg-red-600 hover:bg-red-700'
-								: 'bg-[var(--accent-color)] hover:opacity-80'
-						}`}
-					>
-						{syncStatus.isActive ? '⏹' : '▶'}
-					</button>
+					<div className="sync-status-btn-col">
+						<button
+							type="button"
+							onClick={handleSyncNow}
+							disabled={isProcessing || syncStatus.isActive}
+							className={`sync-action-btn${
+								isProcessing || syncStatus.isActive ? ' disabled' : ''
+							}`}
+						>
+							Sync Now
+						</button>
+						<button
+							type="button"
+							onClick={handleAbortSync}
+							disabled={!syncStatus.isActive}
+							className={`abort-action-btn${!syncStatus.isActive ? ' disabled' : ''}`}
+						>
+							Abort
+						</button>
+					</div>
 					<div className="flex-1">
-                                                <div className="w-full rounded-full h-2 overflow-hidden mb-2 sync-status-progress-bg">
-                                                        <div
-                                                                className="sync-status-progress-bar"
-                                                                style={{ width: `${progressPercentage}%` }}
-                                                        />
-                                                </div>
+						{progressPercentage > 0 && (
+							<div className="w-full rounded-full h-2 overflow-hidden mb-2 sync-status-progress-bg">
+								<div
+									className="sync-status-progress-bar"
+									style={{ width: `${progressPercentage}%` }}
+								></div>
+							</div>
+						)}
+
 						<hr className="sync-status-divider" />
 						<div className="text-xs mt-1 flex justify-between sync-status-info">
 							<span>{syncStatus.isActive ? 'Syncing...' : 'Ready'}</span>
@@ -258,28 +311,33 @@ function SyncStatusWidget() {
 								</p>
 							</>
 						)}
-                                                {syncStatus.libraries && syncStatus.libraries.length > 0 ? (
-                                                        <>
-                                                                <hr className="sync-status-divider" />
-                                                                <div className="sync-status-library-list mt-1 text-xs">
-                                                                        {syncStatus.libraries.map((lib) => (
-                                                                        <div key={lib.name} className="sync-status-library-item">
-                                                                                        <span>{lib.name}</span>
-                                                                                        <span>{Math.round(Math.min(100, Math.max(0, lib.progress * 100)))}%</span>
-                                                                                </div>
-                                                                        ))}
-                                                                </div>
-                                                        </>
-                                                ) : (
-                                                        syncStatus.libraryName && (
-                                                                <>
-                                                                        <hr className="sync-status-divider" />
-                                                                        <p className="text-xs mt-1 font-medium sync-status-library">
-                                                                                {syncStatus.libraryName}
-                                                                        </p>
-                                                                </>
-                                                        )
-                                                )}
+						{syncStatus.libraries && syncStatus.libraries.length > 0 ? (
+							<>
+								<hr className="sync-status-divider" />
+								<div className="sync-status-library-list mt-1 text-xs">
+									{syncStatus.libraries.map((lib) => (
+										<div key={lib.name} className="sync-status-library-item">
+											<span>{lib.name}</span>
+											<span>
+												{Math.round(
+													Math.min(100, Math.max(0, lib.progress * 100))
+												)}
+												%
+											</span>
+										</div>
+									))}
+								</div>
+							</>
+						) : (
+							syncStatus.libraryName && (
+								<>
+									<hr className="sync-status-divider" />
+									<p className="text-xs mt-1 font-medium sync-status-library">
+										{syncStatus.libraryName}
+									</p>
+								</>
+							)
+						)}
 					</div>
 				</div>
 			</div>

--- a/src/widgets/syncStatusWidget.tsx
+++ b/src/widgets/syncStatusWidget.tsx
@@ -231,16 +231,12 @@ function SyncStatusWidget() {
 						{syncStatus.isActive ? '⏹' : '▶'}
 					</button>
 					<div className="flex-1">
-						<div className="w-full rounded-full h-2 overflow-hidden mb-2 sync-status-progress-bg">
-							<div
-								className="sync-status-progress-bar"
-								style={
-									{
-										'--progress-width': `${progressPercentage}%`,
-									} as React.CSSProperties
-								}
-							/>
-						</div>
+                                                <div className="w-full rounded-full h-2 overflow-hidden mb-2 sync-status-progress-bg">
+                                                        <div
+                                                                className="sync-status-progress-bar"
+                                                                style={{ width: `${progressPercentage}%` }}
+                                                        />
+                                                </div>
 						<hr className="sync-status-divider" />
 						<div className="text-xs mt-1 flex justify-between sync-status-info">
 							<span>{syncStatus.isActive ? 'Syncing...' : 'Ready'}</span>
@@ -265,9 +261,9 @@ function SyncStatusWidget() {
                                                 {syncStatus.libraries && syncStatus.libraries.length > 0 ? (
                                                         <>
                                                                 <hr className="sync-status-divider" />
-                                                                <div className="sync-status-library-list mt-1">
+                                                                <div className="sync-status-library-list mt-1 text-xs">
                                                                         {syncStatus.libraries.map((lib) => (
-                                                                                <div key={lib.name} className="sync-status-library-item">
+                                                                        <div key={lib.name} className="sync-status-library-item">
                                                                                         <span>{lib.name}</span>
                                                                                         <span>{Math.round(Math.min(100, Math.max(0, lib.progress * 100)))}%</span>
                                                                                 </div>

--- a/src/widgets/syncStatusWidget.tsx
+++ b/src/widgets/syncStatusWidget.tsx
@@ -93,7 +93,7 @@ function SyncStatusWidget() {
                         const isActive = ((await plugin.storage.getSession('syncing')) as boolean) || false;
                         const startTime = (await plugin.storage.getSession('syncStartTime')) as string | undefined;
                         let timeRemaining: number | undefined = undefined;
-                        if (startTime && progress > 0 && progress < 1) {
+                        if (startTime && progress > 0.01 && progress < 1) {
                                 const start = new Date(startTime).getTime();
                                 const elapsed = Date.now() - start;
                                 const total = elapsed / progress;
@@ -103,13 +103,13 @@ function SyncStatusWidget() {
                         // When syncing multiple libraries, collect progress for each
                         if (multi) {
                                 const progressMap = (await plugin.storage.getSession('multiLibraryProgress')) as
-                                        | Record<string, number>
+                                        | Record<string, { progress: number; name: string }>
                                         | undefined;
                                 const libraries: LibraryEntry[] = [];
                                 if (progressMap) {
                                         for (const [key, val] of Object.entries(progressMap)) {
-                                                const name = await getLibraryName(key);
-                                                libraries.push({ name, progress: val });
+                                                const name = val.name || (await getLibraryName(key));
+                                                libraries.push({ name, progress: val.progress });
                                         }
                                 }
 


### PR DESCRIPTION
## Summary
- track progress per library during multi-library syncs
- aggregate progress across libraries
- display progress for each library in sync widget
- style multi-library progress list

## Testing
- `npm run check-types`

------
https://chatgpt.com/codex/tasks/task_e_686eb1dadcc88324be93d2d10eb6c0df